### PR TITLE
feat: ratatui migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
  "once_cell",
  "open",
  "pulldown-cmark",
+ "ratatui",
  "same-file",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +197,19 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "content_inspector"
@@ -249,6 +271,22 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
@@ -258,7 +296,7 @@ dependencies = [
  "filedescriptor",
  "futures-core",
  "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -1380,6 +1418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "helix-core"
 version = "25.7.1"
 dependencies = [
@@ -1530,7 +1574,7 @@ dependencies = [
  "arc-swap",
  "chrono",
  "content_inspector",
- "crossterm",
+ "crossterm 0.28.1",
  "dashmap",
  "fern",
  "futures-util",
@@ -1575,11 +1619,12 @@ version = "25.7.1"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm",
+ "crossterm 0.28.1",
  "helix-core",
  "helix-view",
  "log",
  "once_cell",
+ "ratatui",
  "termini",
  "unicode-segmentation",
 ]
@@ -1609,7 +1654,7 @@ dependencies = [
  "bitflags",
  "chardetng",
  "clipboard-win",
- "crossterm",
+ "crossterm 0.28.1",
  "futures-util",
  "helix-core",
  "helix-dap",
@@ -1895,6 +1940,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2176,6 +2260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2367,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.27.0",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.12",
 ]
 
 [[package]]
@@ -2393,6 +2503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,7 +2620,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.0.2",
  "signal-hook",
 ]
 
@@ -2581,6 +2698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2724,28 @@ name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -2737,7 +2886,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2891,6 +3040,17 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.12",
+]
 
 [[package]]
 name = "unicode-width"
@@ -3073,6 +3233,15 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3096,6 +3265,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3132,6 +3316,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3144,6 +3334,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3153,6 +3349,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3180,6 +3382,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3189,6 +3397,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3204,6 +3418,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3213,6 +3433,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +200,58 @@ dependencies = [
  "num-traits",
  "windows-link",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clipboard-win"
@@ -242,6 +312,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -312,6 +418,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1382,6 +1494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1741,7 @@ version = "25.7.1"
 dependencies = [
  "bitflags",
  "cassowary",
+ "criterion",
  "crossterm 0.28.1",
  "helix-core",
  "helix-view",
@@ -1686,6 +1809,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -1930,6 +2059,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +2077,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2163,7 +2312,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -2206,7 +2355,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2224,6 +2373,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
@@ -2288,6 +2443,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2862,6 +3045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,6 +3366,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -35,6 +35,7 @@ default = ["git"]
 unicode-lines = ["helix-core/unicode-lines", "helix-view/unicode-lines"]
 integration = ["helix-event/integration_test"]
 git = ["helix-vcs/git"]
+ratatui-migration = ["tui/ratatui-migration", "dep:ratatui"]
 
 [[bin]]
 name = "hx"
@@ -55,6 +56,7 @@ once_cell = "1.21"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.26", optional = true, default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 signal-hook = "0.3"
 tokio-stream = "0.1"

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -44,17 +44,23 @@ use {signal_hook::consts::signal, signal_hook_tokio::Signals};
 #[cfg(windows)]
 type Signals = futures_util::stream::Empty<()>;
 
-#[cfg(not(feature = "integration"))]
+#[cfg(all(not(feature = "integration"), not(feature = "ratatui-migration")))]
 use tui::backend::CrosstermBackend;
 
 #[cfg(feature = "integration")]
 use tui::backend::TestBackend;
 
-#[cfg(not(feature = "integration"))]
+#[cfg(feature = "ratatui-migration")]
+use tui::backend::RatatuiBackendAdapter;
+
+#[cfg(all(not(feature = "integration"), not(feature = "ratatui-migration")))]
 type TerminalBackend = CrosstermBackend<std::io::Stdout>;
 
 #[cfg(feature = "integration")]
 type TerminalBackend = TestBackend;
+
+#[cfg(feature = "ratatui-migration")]
+type TerminalBackend = RatatuiBackendAdapter<ratatui::backend::CrosstermBackend<std::io::Stdout>>;
 
 type Terminal = tui::terminal::Terminal<TerminalBackend>;
 
@@ -103,11 +109,18 @@ impl Application {
         theme_parent_dirs.extend(helix_loader::runtime_dirs().iter().cloned());
         let theme_loader = theme::Loader::new(&theme_parent_dirs);
 
-        #[cfg(not(feature = "integration"))]
+        #[cfg(all(not(feature = "integration"), not(feature = "ratatui-migration")))]
         let backend = CrosstermBackend::new(stdout(), &config.editor);
 
         #[cfg(feature = "integration")]
         let backend = TestBackend::new(120, 150);
+
+        #[cfg(feature = "ratatui-migration")]
+        let backend = {
+            let ratatui_backend = ratatui::backend::CrosstermBackend::new(stdout());
+            RatatuiBackendAdapter::new(ratatui_backend)
+                .expect("Failed to create ratatui backend adapter")
+        };
 
         let terminal = Terminal::new(backend)?;
         let area = terminal.size().expect("couldn't get terminal size");

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -572,8 +572,8 @@ impl Component for Completion {
         surface.clear_with(doc_area, background);
 
         if cx.editor.popup_border() {
-            use tui::widgets::{Block, Widget};
-            Widget::render(Block::bordered(), doc_area, surface);
+            let block = super::widget_compat::bordered_block();
+            super::widget_compat::render_block_widget(block, doc_area, surface);
         }
 
         markdown_doc.render(doc_area, surface, cx);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -727,7 +727,7 @@ impl EditorView {
         
         #[cfg(feature = "ratatui-migration")]
         use {
-            tui::compat::ratatui_compat::{convert_text, render_ratatui_widget},
+            tui::compat::ratatui_compat::{convert_text_ref, render_ratatui_widget},
             tui::text::Text,
         };
 
@@ -784,7 +784,7 @@ impl EditorView {
         #[cfg(feature = "ratatui-migration")]
         {
             // Convert helix text to ratatui text
-            let ratatui_text = convert_text(&text);
+            let ratatui_text = convert_text_ref(&text);
             let paragraph = ratatui::widgets::Paragraph::new(ratatui_text)
                 .alignment(ratatui::layout::Alignment::Right)
                 .wrap(ratatui::widgets::Wrap { trim: true });

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -717,10 +717,18 @@ impl EditorView {
         theme: &Theme,
     ) {
         use helix_core::diagnostic::Severity;
+        
+        #[cfg(not(feature = "ratatui-migration"))]
         use tui::{
             layout::Alignment,
             text::Text,
             widgets::{Paragraph, Widget, Wrap},
+        };
+        
+        #[cfg(feature = "ratatui-migration")]
+        use {
+            tui::compat::ratatui_compat::{convert_text, render_ratatui_widget},
+            tui::text::Text,
         };
 
         let cursor = doc
@@ -761,15 +769,27 @@ impl EditorView {
         }
 
         let text = Text::from(lines);
-        let paragraph = Paragraph::new(&text)
-            .alignment(Alignment::Right)
-            .wrap(Wrap { trim: true });
         let width = 100.min(viewport.width);
         let height = 15.min(viewport.height);
-        paragraph.render(
-            Rect::new(viewport.right() - width, viewport.y + 1, width, height),
-            surface,
-        );
+        let render_area = Rect::new(viewport.right() - width, viewport.y + 1, width, height);
+        
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let paragraph = Paragraph::new(&text)
+                .alignment(Alignment::Right)
+                .wrap(Wrap { trim: true });
+            paragraph.render(render_area, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            // Convert helix text to ratatui text
+            let ratatui_text = convert_text(&text);
+            let paragraph = ratatui::widgets::Paragraph::new(ratatui_text)
+                .alignment(ratatui::layout::Alignment::Right)
+                .wrap(ratatui::widgets::Wrap { trim: true });
+            render_ratatui_widget(paragraph, render_area, surface);
+        }
     }
 
     /// Apply the highlighting on the lines where a cursor is active

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -1,9 +1,20 @@
 use crate::compositor::{Component, Context};
-use helix_view::graphics::{Margin, Rect};
+use helix_view::graphics::Rect;
 use helix_view::info::Info;
 use tui::buffer::Buffer as Surface;
-use tui::text::Text;
-use tui::widgets::{Block, Paragraph, Widget};
+
+#[cfg(feature = "ratatui-migration")]
+use {
+    ratatui::widgets::Block,
+    tui::compat::ratatui_compat::{convert_style, render_ratatui_widget},
+};
+
+#[cfg(not(feature = "ratatui-migration"))]
+use {
+    tui::widgets::{Block, Paragraph, Widget},
+    tui::text::Text,
+    helix_view::graphics::Margin,
+};
 
 impl Component for Info {
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
@@ -23,16 +34,58 @@ impl Component for Info {
         ));
         surface.clear_with(area, popup_style);
 
-        let block = Block::bordered()
-            .title(self.title.as_ref())
-            .border_style(popup_style);
+        #[cfg(not(feature = "ratatui-migration"))]
+        let inner = {
+            let block = Block::bordered()
+                .title(self.title.as_ref())
+                .border_style(popup_style);
 
-        let margin = Margin::horizontal(1);
-        let inner = block.inner(area).inner(margin);
-        block.render(area, surface);
+            let margin = Margin::horizontal(1);
+            let inner = block.inner(area).inner(margin);
+            block.render(area, surface);
+            inner
+        };
 
-        Paragraph::new(&Text::from(self.text.as_str()))
-            .style(text_style)
-            .render(inner, surface);
+        #[cfg(feature = "ratatui-migration")]
+        let inner = {
+            // Create ratatui Block with title (title is Cow<'static, str>, not Option)
+            let block = Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .title(self.title.as_ref()) // title is always present
+                .border_style(convert_style(popup_style));
+
+            // Calculate inner area with margin (need to convert types)
+            let ratatui_area = tui::compat::ratatui_compat::convert_rect(area);
+            let ratatui_inner = block.inner(ratatui_area);
+            
+            // Apply margin using ratatui's margin system
+            let margin = ratatui::layout::Margin { horizontal: 1, vertical: 0 };
+            let ratatui_inner_with_margin = ratatui_inner.inner(&margin);
+            
+            // Convert back to helix rect for compatibility
+            let inner = tui::compat::ratatui_compat::convert_rect_back(ratatui_inner_with_margin);
+            
+            // Render the ratatui Block widget
+            render_ratatui_widget(block, area, surface);
+            inner
+        };
+
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            Paragraph::new(&Text::from(self.text.as_str()))
+                .style(text_style)
+                .render(inner, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            // Use ratatui Paragraph with converted text and style
+            let ratatui_text = ratatui::text::Text::from(self.text.as_str());
+            let ratatui_style = convert_style(text_style);
+            let paragraph = ratatui::widgets::Paragraph::new(ratatui_text)
+                .style(ratatui_style);
+            
+            render_ratatui_widget(paragraph, inner, surface);
+        }
     }
 }

--- a/helix-term/src/ui/lsp/hover.rs
+++ b/helix-term/src/ui/lsp/hover.rs
@@ -6,6 +6,14 @@ use helix_lsp::lsp;
 use helix_view::graphics::{Margin, Rect, Style};
 use helix_view::input::Event;
 use tui::buffer::Buffer;
+
+#[cfg(feature = "ratatui-migration")]
+use {
+    tui::compat::ratatui_compat::{convert_text, render_ratatui_widget},
+    tui::widgets::BorderType,
+};
+
+#[cfg(not(feature = "ratatui-migration"))]
 use tui::widgets::{BorderType, Paragraph, Widget, Wrap};
 
 use crate::compositor::{Component, Context, EventResult};
@@ -81,8 +89,19 @@ impl Component for Hover {
         if let Some(header) = header {
             // header LSP Name
             let header = header.parse(Some(&cx.editor.theme));
-            let header = Paragraph::new(&header);
-            header.render(area.with_height(HEADER_HEIGHT), surface);
+            
+            #[cfg(not(feature = "ratatui-migration"))]
+            {
+                let header = Paragraph::new(&header);
+                header.render(area.with_height(HEADER_HEIGHT), surface);
+            }
+            
+            #[cfg(feature = "ratatui-migration")]
+            {
+                let ratatui_text = convert_text(&header);
+                let header_para = ratatui::widgets::Paragraph::new(ratatui_text);
+                render_ratatui_widget(header_para, area.with_height(HEADER_HEIGHT), surface);
+            }
 
             // border
             let sep_style = Style::default();
@@ -101,10 +120,23 @@ impl Component for Hover {
         } else {
             0
         });
-        let contents_para = Paragraph::new(&contents)
-            .wrap(Wrap { trim: false })
-            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
-        contents_para.render(contents_area, surface);
+        
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let contents_para = Paragraph::new(&contents)
+                .wrap(Wrap { trim: false })
+                .scroll((cx.scroll.unwrap_or_default() as u16, 0));
+            contents_para.render(contents_area, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            let ratatui_text = convert_text(&contents);
+            let contents_para = ratatui::widgets::Paragraph::new(ratatui_text)
+                .wrap(ratatui::widgets::Wrap { trim: false })
+                .scroll((cx.scroll.unwrap_or_default() as u16, 0));
+            render_ratatui_widget(contents_para, contents_area, surface);
+        }
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {

--- a/helix-term/src/ui/lsp/hover.rs
+++ b/helix-term/src/ui/lsp/hover.rs
@@ -9,7 +9,7 @@ use tui::buffer::Buffer;
 
 #[cfg(feature = "ratatui-migration")]
 use {
-    tui::compat::ratatui_compat::{convert_text, render_ratatui_widget},
+    tui::compat::ratatui_compat::{convert_text_ref, render_ratatui_widget},
     tui::widgets::BorderType,
 };
 
@@ -98,7 +98,7 @@ impl Component for Hover {
             
             #[cfg(feature = "ratatui-migration")]
             {
-                let ratatui_text = convert_text(&header);
+                let ratatui_text = convert_text_ref(&header);
                 let header_para = ratatui::widgets::Paragraph::new(ratatui_text);
                 render_ratatui_widget(header_para, area.with_height(HEADER_HEIGHT), surface);
             }
@@ -131,7 +131,7 @@ impl Component for Hover {
         
         #[cfg(feature = "ratatui-migration")]
         {
-            let ratatui_text = convert_text(&contents);
+            let ratatui_text = convert_text_ref(&contents);
             let contents_para = ratatui::widgets::Paragraph::new(ratatui_text)
                 .wrap(ratatui::widgets::Wrap { trim: false })
                 .scroll((cx.scroll.unwrap_or_default() as u16, 0));

--- a/helix-term/src/ui/lsp/signature_help.rs
+++ b/helix-term/src/ui/lsp/signature_help.rs
@@ -15,7 +15,7 @@ use tui::{
 };
 
 #[cfg(feature = "ratatui-migration")]
-use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
+use tui::compat::ratatui_compat::{convert_text_ref, render_ratatui_widget};
 
 use crate::compositor::{Component, Compositor, Context, EventResult};
 
@@ -145,7 +145,7 @@ impl Component for SignatureHelp {
             
             #[cfg(feature = "ratatui-migration")]
             {
-                let ratatui_text = convert_text(&text);
+                let ratatui_text = convert_text_ref(&text);
                 let paragraph = ratatui::widgets::Paragraph::new(ratatui_text)
                     .alignment(ratatui::layout::Alignment::Right);
                 render_ratatui_widget(paragraph, render_area, surface);
@@ -168,7 +168,7 @@ impl Component for SignatureHelp {
         
         #[cfg(feature = "ratatui-migration")]
         let (sig_text_area, _sig_text_height) = {
-            let ratatui_text = convert_text(&sig_text);
+            let ratatui_text = convert_text_ref(&sig_text);
             let sig_text_para = ratatui::widgets::Paragraph::new(ratatui_text)
                 .wrap(ratatui::widgets::Wrap { trim: false })
                 .scroll(scroll_offset);
@@ -211,7 +211,7 @@ impl Component for SignatureHelp {
         
         #[cfg(feature = "ratatui-migration")]
         {
-            let ratatui_text = convert_text(&sig_doc);
+            let ratatui_text = convert_text_ref(&sig_doc);
             let sig_doc_para = ratatui::widgets::Paragraph::new(ratatui_text)
                 .wrap(ratatui::widgets::Wrap { trim: false })
                 .scroll(scroll_offset);

--- a/helix-term/src/ui/lsp/signature_help.rs
+++ b/helix-term/src/ui/lsp/signature_help.rs
@@ -5,9 +5,17 @@ use helix_core::syntax::{self, OverlayHighlights};
 use helix_view::graphics::{Margin, Rect, Style};
 use helix_view::input::Event;
 use tui::buffer::Buffer;
-use tui::layout::Alignment;
 use tui::text::Text;
-use tui::widgets::{BorderType, Paragraph, Widget, Wrap};
+use tui::widgets::BorderType;
+
+#[cfg(not(feature = "ratatui-migration"))]
+use tui::{
+    layout::Alignment,
+    widgets::{Paragraph, Widget, Wrap},
+};
+
+#[cfg(feature = "ratatui-migration")]
+use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
 
 use crate::compositor::{Component, Compositor, Context, EventResult};
 
@@ -127,17 +135,49 @@ impl Component for SignatureHelp {
         if self.signatures.len() > 1 {
             let signature_index = self.signature_index();
             let text = Text::from(signature_index);
-            let paragraph = Paragraph::new(&text).alignment(Alignment::Right);
-            paragraph.render(area.with_height(1).clip_right(1), surface);
+            let render_area = area.with_height(1).clip_right(1);
+            
+            #[cfg(not(feature = "ratatui-migration"))]
+            {
+                let paragraph = Paragraph::new(&text).alignment(Alignment::Right);
+                paragraph.render(render_area, surface);
+            }
+            
+            #[cfg(feature = "ratatui-migration")]
+            {
+                let ratatui_text = convert_text(&text);
+                let paragraph = ratatui::widgets::Paragraph::new(ratatui_text)
+                    .alignment(ratatui::layout::Alignment::Right);
+                render_ratatui_widget(paragraph, render_area, surface);
+            }
         }
 
-        let sig_text_para = Paragraph::new(&sig_text)
-            .wrap(Wrap { trim: false })
-            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
-        let (_, sig_text_height) = sig_text_para.required_size(area.width);
-        let sig_text_area = area.with_height(sig_text_height.min(area.height));
-        let sig_text_area = sig_text_area.intersection(surface.area);
-        sig_text_para.render(sig_text_area, surface);
+        let scroll_offset = (cx.scroll.unwrap_or_default() as u16, 0);
+        
+        #[cfg(not(feature = "ratatui-migration"))]
+        let (sig_text_area, _sig_text_height) = {
+            let sig_text_para = Paragraph::new(&sig_text)
+                .wrap(Wrap { trim: false })
+                .scroll(scroll_offset);
+            let (_, sig_text_height) = sig_text_para.required_size(area.width);
+            let sig_text_area = area.with_height(sig_text_height.min(area.height));
+            let sig_text_area = sig_text_area.intersection(surface.area);
+            sig_text_para.render(sig_text_area, surface);
+            (sig_text_area, sig_text_height)
+        };
+        
+        #[cfg(feature = "ratatui-migration")]
+        let (sig_text_area, _sig_text_height) = {
+            let ratatui_text = convert_text(&sig_text);
+            let sig_text_para = ratatui::widgets::Paragraph::new(ratatui_text)
+                .wrap(ratatui::widgets::Wrap { trim: false })
+                .scroll(scroll_offset);
+            let (_, sig_text_height) = crate::ui::text::required_size(&sig_text, area.width);
+            let sig_text_area = area.with_height(sig_text_height.min(area.height));
+            let sig_text_area = sig_text_area.intersection(surface.area);
+            render_ratatui_widget(sig_text_para, sig_text_area, surface);
+            (sig_text_area, sig_text_height)
+        };
 
         if signature.signature_doc.is_none() {
             return;
@@ -159,10 +199,24 @@ impl Component for SignatureHelp {
         let sig_doc_area = area
             .clip_top(sig_text_area.height + 2)
             .clip_bottom(u16::from(cx.editor.popup_border()));
-        let sig_doc_para = Paragraph::new(&sig_doc)
-            .wrap(Wrap { trim: false })
-            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
-        sig_doc_para.render(sig_doc_area, surface);
+        let scroll_offset = (cx.scroll.unwrap_or_default() as u16, 0);
+        
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let sig_doc_para = Paragraph::new(&sig_doc)
+                .wrap(Wrap { trim: false })
+                .scroll(scroll_offset);
+            sig_doc_para.render(sig_doc_area, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            let ratatui_text = convert_text(&sig_doc);
+            let sig_doc_para = ratatui::widgets::Paragraph::new(ratatui_text)
+                .wrap(ratatui::widgets::Wrap { trim: false })
+                .scroll(scroll_offset);
+            render_ratatui_widget(sig_doc_para, sig_doc_area, surface);
+        }
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {
@@ -183,8 +237,14 @@ impl Component for SignatureHelp {
             &self.config_loader.load(),
             None,
         );
-        let sig_text_para = Paragraph::new(&signature_text).wrap(Wrap { trim: false });
-        let (sig_width, sig_height) = sig_text_para.required_size(max_text_width);
+        #[cfg(not(feature = "ratatui-migration"))]
+        let (sig_width, sig_height) = {
+            let sig_text_para = Paragraph::new(&signature_text).wrap(Wrap { trim: false });
+            sig_text_para.required_size(max_text_width)
+        };
+        
+        #[cfg(feature = "ratatui-migration")]
+        let (sig_width, sig_height) = crate::ui::text::required_size(&signature_text, max_text_width);
 
         let (width, height) = match signature.signature_doc {
             Some(ref doc) => {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -367,16 +367,30 @@ impl Markdown {
 
 impl Component for Markdown {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
-        use tui::widgets::{Paragraph, Widget, Wrap};
-
         let text = self.parse(Some(&cx.editor.theme));
-
-        let par = Paragraph::new(&text)
-            .wrap(Wrap { trim: false })
-            .scroll((cx.scroll.unwrap_or_default() as u16, 0));
-
         let margin = Margin::all(1);
-        par.render(area.inner(margin), surface);
+        let inner_area = area.inner(margin);
+
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            use tui::widgets::{Paragraph, Widget, Wrap};
+            let par = Paragraph::new(&text)
+                .wrap(Wrap { trim: false })
+                .scroll((cx.scroll.unwrap_or_default() as u16, 0));
+            par.render(inner_area, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
+            
+            // Convert helix text to ratatui text
+            let ratatui_text = convert_text(&text);
+            let par = ratatui::widgets::Paragraph::new(ratatui_text)
+                .wrap(ratatui::widgets::Wrap { trim: false })
+                .scroll((cx.scroll.unwrap_or_default() as u16, 0));
+            render_ratatui_widget(par, inner_area, surface);
+        }
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -382,10 +382,10 @@ impl Component for Markdown {
         
         #[cfg(feature = "ratatui-migration")]
         {
-            use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
+            use tui::compat::ratatui_compat::{convert_text_ref, render_ratatui_widget};
             
             // Convert helix text to ratatui text
-            let ratatui_text = convert_text(&text);
+            let ratatui_text = convert_text_ref(&text);
             let par = ratatui::widgets::Paragraph::new(ratatui_text)
                 .wrap(ratatui::widgets::Wrap { trim: false })
                 .scroll((cx.scroll.unwrap_or_default() as u16, 0));

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -2,11 +2,8 @@ use crate::{
     compositor::{Callback, Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
 };
-#[cfg(not(feature = "ratatui-migration"))]
-use tui::{buffer::Buffer as Surface, widgets::Table};
-
-#[cfg(feature = "ratatui-migration")]
 use tui::buffer::Buffer as Surface;
+use tui::widgets::Table;
 
 pub use tui::widgets::{Cell, Row};
 
@@ -320,51 +317,16 @@ impl<T: Item + 'static> Component for Menu<T> {
             .iter()
             .map(|option| option.format(&self.editor_data));
         let render_area = area.clip_left(Self::LEFT_PADDING as u16).clip_right(1);
-        let mut table_state = tui::widgets::TableState {
-            offset: scroll,
-            selected: self.cursor,
-        };
         
-        #[cfg(not(feature = "ratatui-migration"))]
-        {
-            let table = Table::new(rows)
-                .style(style)
-                .highlight_style(selected)
-                .column_spacing(1)
-                .widths(&self.widths);
-            table.render_table(render_area, surface, &mut table_state, false);
-        }
+        let table = Table::new(rows)
+            .style(style)
+            .highlight_style(selected)
+            .column_spacing(1)
+            .widths(&self.widths);
         
-        #[cfg(feature = "ratatui-migration")]
-        {
-            let table = tui::widgets::Table::new(rows)
-                .style(style)
-                .highlight_style(selected)
-                .column_spacing(1)
-                .widths(&self.widths);
-            let ratatui_table = table.to_ratatui_table();
-            let mut ratatui_state = tui::compat::ratatui_compat::convert_table_state(&table_state);
-            
-            // Render with ratatui
-            use ratatui::widgets::StatefulWidget;
-            let ratatui_area = tui::compat::ratatui_compat::convert_rect(render_area);
-            let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
-            ratatui_table.render(ratatui_area, &mut ratatui_buffer, &mut ratatui_state);
-            
-            // Copy back to helix buffer
-            for y in ratatui_area.top()..ratatui_area.bottom() {
-                for x in ratatui_area.left()..ratatui_area.right() {
-                    let ratatui_cell = ratatui_buffer.get(x, y);
-                    if let Some(helix_cell_pos) = surface.get_mut(x, y) {
-                        let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
-                        *helix_cell_pos = helix_cell;
-                    }
-                }
-            }
-            
-            // Update state
-            tui::compat::ratatui_compat::update_table_state_from_ratatui(&mut table_state, &ratatui_state);
-        }
+        use super::table_compat;
+        let mut table_state = table_compat::table_state(scroll, self.cursor);
+        table_compat::render_table(table, render_area, surface, &mut table_state, false);
 
         let render_borders = cx.editor.menu_border();
 

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -2,7 +2,11 @@ use crate::{
     compositor::{Callback, Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
 };
+#[cfg(not(feature = "ratatui-migration"))]
 use tui::{buffer::Buffer as Surface, widgets::Table};
+
+#[cfg(feature = "ratatui-migration")]
+use tui::buffer::Buffer as Surface;
 
 pub use tui::widgets::{Cell, Row};
 
@@ -315,23 +319,52 @@ impl<T: Item + 'static> Component for Menu<T> {
         let rows = options
             .iter()
             .map(|option| option.format(&self.editor_data));
-        let table = Table::new(rows)
-            .style(style)
-            .highlight_style(selected)
-            .column_spacing(1)
-            .widths(&self.widths);
-
-        use tui::widgets::TableState;
-
-        table.render_table(
-            area.clip_left(Self::LEFT_PADDING as u16).clip_right(1),
-            surface,
-            &mut TableState {
-                offset: scroll,
-                selected: self.cursor,
-            },
-            false,
-        );
+        let render_area = area.clip_left(Self::LEFT_PADDING as u16).clip_right(1);
+        let mut table_state = tui::widgets::TableState {
+            offset: scroll,
+            selected: self.cursor,
+        };
+        
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let table = Table::new(rows)
+                .style(style)
+                .highlight_style(selected)
+                .column_spacing(1)
+                .widths(&self.widths);
+            table.render_table(render_area, surface, &mut table_state, false);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            let table = tui::widgets::Table::new(rows)
+                .style(style)
+                .highlight_style(selected)
+                .column_spacing(1)
+                .widths(&self.widths);
+            let ratatui_table = table.to_ratatui_table();
+            let mut ratatui_state = tui::compat::ratatui_compat::convert_table_state(&table_state);
+            
+            // Render with ratatui
+            use ratatui::widgets::StatefulWidget;
+            let ratatui_area = tui::compat::ratatui_compat::convert_rect(render_area);
+            let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
+            ratatui_table.render(ratatui_area, &mut ratatui_buffer, &mut ratatui_state);
+            
+            // Copy back to helix buffer
+            for y in ratatui_area.top()..ratatui_area.bottom() {
+                for x in ratatui_area.left()..ratatui_area.right() {
+                    let ratatui_cell = ratatui_buffer.get(x, y);
+                    if let Some(helix_cell_pos) = surface.get_mut(x, y) {
+                        let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
+                        *helix_cell_pos = helix_cell;
+                    }
+                }
+            }
+            
+            // Update state
+            tui::compat::ratatui_compat::update_table_state_from_ratatui(&mut table_state, &ratatui_state);
+        }
 
         let render_borders = cx.editor.menu_border();
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -11,6 +11,8 @@ pub mod popup;
 pub mod prompt;
 mod spinner;
 mod statusline;
+mod table_compat;
+pub mod widget_compat;
 mod text;
 mod text_decorations;
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -23,8 +23,11 @@ use tui::{
     buffer::Buffer as Surface,
     layout::Constraint,
     text::{Span, Spans},
-    widgets::{Block, BorderType, Cell, Row, Table},
+    widgets::{Block, BorderType, Cell, Row},
 };
+
+#[cfg(not(feature = "ratatui-migration"))]
+use tui::widgets::Table;
 
 use tui::widgets::Widget;
 
@@ -823,49 +826,110 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             }))
         });
 
-        let mut table = Table::new(options)
-            .style(text_style)
-            .highlight_style(selected)
-            .highlight_symbol(" > ")
-            .column_spacing(1)
-            .widths(&self.widths);
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let mut table = Table::new(options)
+                .style(text_style)
+                .highlight_style(selected)
+                .highlight_symbol(" > ")
+                .column_spacing(1)
+                .widths(&self.widths);
 
-        // -- Header
-        if self.columns.len() > 1 {
-            let active_column = self.query.active_column(self.prompt.position());
-            let header_style = cx.editor.theme.get("ui.picker.header");
-            let header_column_style = cx.editor.theme.get("ui.picker.header.column");
+            // -- Header
+            if self.columns.len() > 1 {
+                let active_column = self.query.active_column(self.prompt.position());
+                let header_style = cx.editor.theme.get("ui.picker.header");
+                let header_column_style = cx.editor.theme.get("ui.picker.header.column");
 
-            table = table.header(
-                Row::new(self.columns.iter().map(|column| {
-                    if column.hidden {
-                        Cell::default()
-                    } else {
-                        let style =
-                            if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
-                                cx.editor.theme.get("ui.picker.header.column.active")
-                            } else {
-                                header_column_style
-                            };
+                table = table.header(
+                    Row::new(self.columns.iter().map(|column| {
+                        if column.hidden {
+                            Cell::default()
+                        } else {
+                            let style =
+                                if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
+                                    cx.editor.theme.get("ui.picker.header.column.active")
+                                } else {
+                                    header_column_style
+                                };
 
-                        Cell::from(Span::styled(Cow::from(&*column.name), style))
-                    }
-                }))
-                .style(header_style),
+                            Cell::from(Span::styled(Cow::from(&*column.name), style))
+                        }
+                    }))
+                    .style(header_style),
+                );
+            }
+
+            use tui::widgets::TableState;
+
+            table.render_table(
+                inner,
+                surface,
+                &mut TableState {
+                    offset: 0,
+                    selected: Some(cursor as usize),
+                },
+                self.truncate_start,
             );
         }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            let mut table = tui::widgets::Table::new(options)
+                .style(text_style)
+                .highlight_style(selected)
+                .highlight_symbol(" > ")
+                .column_spacing(1)
+                .widths(&self.widths);
 
-        use tui::widgets::TableState;
+            // -- Header
+            if self.columns.len() > 1 {
+                let active_column = self.query.active_column(self.prompt.position());
+                let header_style = cx.editor.theme.get("ui.picker.header");
+                let header_column_style = cx.editor.theme.get("ui.picker.header.column");
 
-        table.render_table(
-            inner,
-            surface,
-            &mut TableState {
+                table = table.header(
+                    Row::new(self.columns.iter().map(|column| {
+                        if column.hidden {
+                            Cell::default()
+                        } else {
+                            let style =
+                                if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
+                                    cx.editor.theme.get("ui.picker.header.column.active")
+                                } else {
+                                    header_column_style
+                                };
+
+                            Cell::from(Span::styled(Cow::from(&*column.name), style))
+                        }
+                    }))
+                    .style(header_style),
+                );
+            }
+
+            let ratatui_table = table.to_ratatui_table();
+            let mut ratatui_state = tui::compat::ratatui_compat::convert_table_state(&tui::widgets::TableState {
                 offset: 0,
                 selected: Some(cursor as usize),
-            },
-            self.truncate_start,
-        );
+            });
+            
+            // Render with ratatui
+            use ratatui::widgets::StatefulWidget;
+            let ratatui_area = tui::compat::ratatui_compat::convert_rect(inner);
+            let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
+            ratatui_table.render(ratatui_area, &mut ratatui_buffer, &mut ratatui_state);
+            
+            // Copy back to helix buffer
+            for y in ratatui_area.top()..ratatui_area.bottom() {
+                for x in ratatui_area.left()..ratatui_area.right() {
+                    let ratatui_cell = ratatui_buffer.get(x, y);
+                    if let Some(helix_cell_pos) = surface.get_mut(x, y) {
+                        let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
+                        *helix_cell_pos = helix_cell;
+                    }
+                }
+            }
+        }
     }
 
     fn render_preview(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -23,13 +23,11 @@ use tui::{
     buffer::Buffer as Surface,
     layout::Constraint,
     text::{Span, Spans},
-    widgets::{Block, BorderType, Cell, Row},
+    widgets::{BorderType, Cell, Row, Table},
 };
 
 #[cfg(not(feature = "ratatui-migration"))]
-use tui::widgets::Table;
-
-use tui::widgets::Widget;
+use tui::widgets::{Block, Widget};
 
 use std::{
     borrow::Cow,
@@ -690,12 +688,12 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let background = cx.editor.theme.get("ui.background");
         surface.clear_with(area, background);
 
-        const BLOCK: Block<'_> = Block::bordered();
+        let block = super::widget_compat::bordered_block();
 
         // calculate the inner area inside the box
-        let inner = BLOCK.inner(area);
+        let inner = super::widget_compat::get_block_inner_area(&block, area);
 
-        BLOCK.render(area, surface);
+        super::widget_compat::render_block_widget(block, area, surface);
 
         // -- Render the input bar:
 
@@ -826,110 +824,41 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             }))
         });
 
-        #[cfg(not(feature = "ratatui-migration"))]
-        {
-            let mut table = Table::new(options)
-                .style(text_style)
-                .highlight_style(selected)
-                .highlight_symbol(" > ")
-                .column_spacing(1)
-                .widths(&self.widths);
+        let mut table = Table::new(options)
+            .style(text_style)
+            .highlight_style(selected)
+            .highlight_symbol(" > ")
+            .column_spacing(1)
+            .widths(&self.widths);
 
-            // -- Header
-            if self.columns.len() > 1 {
-                let active_column = self.query.active_column(self.prompt.position());
-                let header_style = cx.editor.theme.get("ui.picker.header");
-                let header_column_style = cx.editor.theme.get("ui.picker.header.column");
+        // -- Header
+        if self.columns.len() > 1 {
+            let active_column = self.query.active_column(self.prompt.position());
+            let header_style = cx.editor.theme.get("ui.picker.header");
+            let header_column_style = cx.editor.theme.get("ui.picker.header.column");
 
-                table = table.header(
-                    Row::new(self.columns.iter().map(|column| {
-                        if column.hidden {
-                            Cell::default()
-                        } else {
-                            let style =
-                                if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
-                                    cx.editor.theme.get("ui.picker.header.column.active")
-                                } else {
-                                    header_column_style
-                                };
+            table = table.header(
+                Row::new(self.columns.iter().map(|column| {
+                    if column.hidden {
+                        Cell::default()
+                    } else {
+                        let style =
+                            if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
+                                cx.editor.theme.get("ui.picker.header.column.active")
+                            } else {
+                                header_column_style
+                            };
 
-                            Cell::from(Span::styled(Cow::from(&*column.name), style))
-                        }
-                    }))
-                    .style(header_style),
-                );
-            }
-
-            use tui::widgets::TableState;
-
-            table.render_table(
-                inner,
-                surface,
-                &mut TableState {
-                    offset: 0,
-                    selected: Some(cursor as usize),
-                },
-                self.truncate_start,
+                        Cell::from(Span::styled(Cow::from(&*column.name), style))
+                    }
+                }))
+                .style(header_style),
             );
         }
-        
-        #[cfg(feature = "ratatui-migration")]
-        {
-            let mut table = tui::widgets::Table::new(options)
-                .style(text_style)
-                .highlight_style(selected)
-                .highlight_symbol(" > ")
-                .column_spacing(1)
-                .widths(&self.widths);
 
-            // -- Header
-            if self.columns.len() > 1 {
-                let active_column = self.query.active_column(self.prompt.position());
-                let header_style = cx.editor.theme.get("ui.picker.header");
-                let header_column_style = cx.editor.theme.get("ui.picker.header.column");
-
-                table = table.header(
-                    Row::new(self.columns.iter().map(|column| {
-                        if column.hidden {
-                            Cell::default()
-                        } else {
-                            let style =
-                                if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
-                                    cx.editor.theme.get("ui.picker.header.column.active")
-                                } else {
-                                    header_column_style
-                                };
-
-                            Cell::from(Span::styled(Cow::from(&*column.name), style))
-                        }
-                    }))
-                    .style(header_style),
-                );
-            }
-
-            let ratatui_table = table.to_ratatui_table();
-            let mut ratatui_state = tui::compat::ratatui_compat::convert_table_state(&tui::widgets::TableState {
-                offset: 0,
-                selected: Some(cursor as usize),
-            });
-            
-            // Render with ratatui
-            use ratatui::widgets::StatefulWidget;
-            let ratatui_area = tui::compat::ratatui_compat::convert_rect(inner);
-            let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
-            ratatui_table.render(ratatui_area, &mut ratatui_buffer, &mut ratatui_state);
-            
-            // Copy back to helix buffer
-            for y in ratatui_area.top()..ratatui_area.bottom() {
-                for x in ratatui_area.left()..ratatui_area.right() {
-                    let ratatui_cell = ratatui_buffer.get(x, y);
-                    if let Some(helix_cell_pos) = surface.get_mut(x, y) {
-                        let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
-                        *helix_cell_pos = helix_cell;
-                    }
-                }
-            }
-        }
+        use super::table_compat;
+        let mut state = table_compat::table_state(0, Some(cursor as usize));
+        table_compat::render_table(table, inner, surface, &mut state, self.truncate_start);
     }
 
     fn render_preview(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
@@ -940,14 +869,14 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let directory = cx.editor.theme.get("ui.text.directory");
         surface.clear_with(area, background);
 
-        const BLOCK: Block<'_> = Block::bordered();
+        let block = super::widget_compat::bordered_block();
 
         // calculate the inner area inside the box
-        let inner = BLOCK.inner(area);
+        let inner = super::widget_compat::get_block_inner_area(&block, area);
         // 1 column gap on either side
         let margin = Margin::horizontal(1);
         let inner = inner.inner(margin);
-        BLOCK.render(area, surface);
+        super::widget_compat::render_block_widget(block, area, surface);
 
         if let Some((preview, range)) = self.get_preview(cx.editor) {
             let doc = match preview.document() {
@@ -1204,9 +1133,9 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
     }
 
     fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
-        let block = Block::bordered();
+        let block = super::widget_compat::bordered_block();
         // calculate the inner area inside the box
-        let inner = block.inner(area);
+        let inner = super::widget_compat::get_block_inner_area(&block, area);
 
         // prompt area
         let render_preview =

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -3,10 +3,10 @@ use crate::{
     compositor::{Callback, Component, Context, Event, EventResult},
     ctrl, key,
 };
-use tui::{
-    buffer::Buffer as Surface,
-    widgets::{Block, Widget},
-};
+use tui::buffer::Buffer as Surface;
+
+#[cfg(not(feature = "ratatui-migration"))]
+use tui::widgets::{Block, Widget};
 
 use helix_core::Position;
 use helix_view::{
@@ -324,7 +324,8 @@ impl<T: Component> Component for Popup<T> {
         let mut inner = area;
         if render_borders {
             inner = area.inner(Margin::all(1));
-            Widget::render(Block::bordered(), area, surface);
+            let block = super::widget_compat::bordered_block();
+            super::widget_compat::render_block_widget(block, area, surface);
         }
         let border = usize::from(render_borders);
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::{borrow::Cow, ops::RangeFrom};
 use tui::buffer::Buffer as Surface;
 use tui::text::Span;
+#[cfg(not(feature = "ratatui-migration"))]
 use tui::widgets::{Block, Widget};
 
 use helix_core::{
@@ -496,13 +497,11 @@ impl Prompt {
             let background = theme.get("ui.help");
             surface.clear_with(area, background);
 
-            let block = Block::bordered()
-                // .title(self.title.as_str())
-                .border_style(background);
+            let block = super::widget_compat::bordered_block();
 
-            let inner = block.inner(area).inner(Margin::horizontal(1));
+            let inner = super::widget_compat::get_block_inner_area(&block, area).inner(Margin::horizontal(1));
 
-            block.render(area, surface);
+            super::widget_compat::render_block_widget(block, area, surface);
             text.render(inner, surface, cx);
         }
 

--- a/helix-term/src/ui/table_compat.rs
+++ b/helix-term/src/ui/table_compat.rs
@@ -42,7 +42,14 @@ pub fn render_table<'a>(
             for x in ratatui_area.left()..ratatui_area.right() {
                 let ratatui_cell = ratatui_buffer.get(x, y);
                 if let Some(helix_cell_pos) = surface.get_mut(x, y) {
-                    let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
+                    let mut helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
+                    
+                    // If the original helix cell has a background but the ratatui cell doesn't,
+                    // preserve the original background to maintain popup styling
+                    if helix_cell.bg == helix_view::graphics::Color::Reset && helix_cell_pos.bg != helix_view::graphics::Color::Reset {
+                        helix_cell.bg = helix_cell_pos.bg;
+                    }
+                    
                     *helix_cell_pos = helix_cell;
                 }
             }

--- a/helix-term/src/ui/table_compat.rs
+++ b/helix-term/src/ui/table_compat.rs
@@ -1,0 +1,60 @@
+//! Compatibility helper for Table widget migration from helix_tui to ratatui
+//!
+//! This module provides a unified interface for rendering tables that works
+//! with both the legacy helix_tui and the new ratatui backend.
+
+use helix_view::graphics::Rect;
+use tui::buffer::Buffer as Surface;
+use tui::widgets::{TableState, Table};
+
+/// Render a table widget using the appropriate backend based on feature flags
+///
+/// This function abstracts the rendering logic to work with both helix_tui
+/// and ratatui Table widgets, handling the conversion and buffer management
+/// automatically.
+pub fn render_table<'a>(
+    table: Table<'a>,
+    area: Rect,
+    surface: &mut Surface,
+    state: &mut TableState,
+    _truncate_start: bool,
+) {
+    #[cfg(not(feature = "ratatui-migration"))]
+    {
+        // Use the original helix_tui Table rendering
+        table.render_table(area, surface, state, _truncate_start);
+    }
+    
+    #[cfg(feature = "ratatui-migration")]
+    {
+        // Convert to ratatui and render
+        let ratatui_table = table.to_ratatui_table();
+        let mut ratatui_state = tui::compat::ratatui_compat::convert_table_state(state);
+        
+        // Render with ratatui
+        use ratatui::widgets::StatefulWidget;
+        let ratatui_area = tui::compat::ratatui_compat::convert_rect(area);
+        let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
+        ratatui_table.render(ratatui_area, &mut ratatui_buffer, &mut ratatui_state);
+        
+        // Copy back to helix buffer
+        for y in ratatui_area.top()..ratatui_area.bottom() {
+            for x in ratatui_area.left()..ratatui_area.right() {
+                let ratatui_cell = ratatui_buffer.get(x, y);
+                if let Some(helix_cell_pos) = surface.get_mut(x, y) {
+                    let helix_cell = tui::compat::ratatui_compat::convert_cell_back(ratatui_cell);
+                    *helix_cell_pos = helix_cell;
+                }
+            }
+        }
+        
+        // Update state
+        tui::compat::ratatui_compat::update_table_state_from_ratatui(state, &ratatui_state);
+    }
+}
+
+/// Helper to create a TableState with the given parameters
+#[inline]
+pub fn table_state(offset: usize, selected: Option<usize>) -> TableState {
+    TableState { offset, selected }
+}

--- a/helix-term/src/ui/text.rs
+++ b/helix-term/src/ui/text.rs
@@ -3,7 +3,7 @@ use tui::buffer::Buffer as Surface;
 use helix_view::graphics::Rect;
 
 #[cfg(feature = "ratatui-migration")]
-use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
+use tui::compat::ratatui_compat::{convert_text_ref, render_ratatui_widget};
 
 #[cfg(not(feature = "ratatui-migration"))]
 use tui::widgets::{Paragraph, Widget, Wrap};
@@ -45,7 +45,7 @@ impl Component for Text {
         #[cfg(feature = "ratatui-migration")]
         {
             // Convert helix text to ratatui text
-            let ratatui_text = convert_text(&self.contents);
+            let ratatui_text = convert_text_ref(&self.contents);
             let par = ratatui::widgets::Paragraph::new(ratatui_text)
                 .wrap(ratatui::widgets::Wrap { trim: false });
             render_ratatui_widget(par, area, surface);

--- a/helix-term/src/ui/text.rs
+++ b/helix-term/src/ui/text.rs
@@ -1,7 +1,12 @@
 use crate::compositor::{Component, Context};
 use tui::buffer::Buffer as Surface;
-
 use helix_view::graphics::Rect;
+
+#[cfg(feature = "ratatui-migration")]
+use tui::compat::ratatui_compat::{convert_text, render_ratatui_widget};
+
+#[cfg(not(feature = "ratatui-migration"))]
+use tui::widgets::{Paragraph, Widget, Wrap};
 
 pub struct Text {
     pub(crate) contents: tui::text::Text<'static>,
@@ -31,12 +36,20 @@ impl From<tui::text::Text<'static>> for Text {
 
 impl Component for Text {
     fn render(&mut self, area: Rect, surface: &mut Surface, _cx: &mut Context) {
-        use tui::widgets::{Paragraph, Widget, Wrap};
-
-        let par = Paragraph::new(&self.contents).wrap(Wrap { trim: false });
-        // .scroll(x, y) offsets
-
-        par.render(area, surface);
+        #[cfg(not(feature = "ratatui-migration"))]
+        {
+            let par = Paragraph::new(&self.contents).wrap(Wrap { trim: false });
+            par.render(area, surface);
+        }
+        
+        #[cfg(feature = "ratatui-migration")]
+        {
+            // Convert helix text to ratatui text
+            let ratatui_text = convert_text(&self.contents);
+            let par = ratatui::widgets::Paragraph::new(ratatui_text)
+                .wrap(ratatui::widgets::Wrap { trim: false });
+            render_ratatui_widget(par, area, surface);
+        }
     }
 
     fn required_size(&mut self, viewport: (u16, u16)) -> Option<(u16, u16)> {

--- a/helix-term/src/ui/widget_compat.rs
+++ b/helix-term/src/ui/widget_compat.rs
@@ -1,0 +1,59 @@
+//! Widget compatibility layer for gradual migration to ratatui
+//!
+//! This module provides helper functions to render various widgets
+//! with conditional compilation, allowing the use of either helix_tui
+//! or ratatui backends based on the feature flag.
+
+use tui::buffer::Buffer as Surface;
+use helix_view::graphics::Rect;
+
+#[cfg(feature = "ratatui-migration")]
+use tui::compat::ratatui_compat::{render_block, render_paragraph_ref};
+
+#[cfg(not(feature = "ratatui-migration"))]
+use tui::widgets::{Block, Paragraph, Widget, Wrap};
+
+/// Render a Block widget with compatibility support
+pub fn render_block_widget(block: tui::widgets::Block<'_>, area: Rect, surface: &mut Surface) {
+    #[cfg(not(feature = "ratatui-migration"))]
+    {
+        block.render(area, surface);
+    }
+    
+    #[cfg(feature = "ratatui-migration")]
+    {
+        render_block(block, area, surface);
+    }
+}
+
+/// Render a Paragraph widget with compatibility support
+pub fn render_paragraph_widget(
+    text: &tui::text::Text<'_>,
+    wrap: Option<tui::widgets::Wrap>,
+    area: Rect,
+    surface: &mut Surface,
+) {
+    #[cfg(not(feature = "ratatui-migration"))]
+    {
+        let mut paragraph = Paragraph::new(text);
+        if let Some(wrap_config) = wrap {
+            paragraph = paragraph.wrap(Wrap { trim: wrap_config.trim });
+        }
+        paragraph.render(area, surface);
+    }
+    
+    #[cfg(feature = "ratatui-migration")]
+    {
+        render_paragraph_ref(text, wrap, area, surface);
+    }
+}
+
+/// Get inner area from Block with compatibility support
+pub fn get_block_inner_area(block: &tui::widgets::Block<'_>, area: Rect) -> Rect {
+    block.inner(area)
+}
+
+/// Create a bordered Block with compatibility support
+pub fn bordered_block() -> tui::widgets::Block<'static> {
+    tui::widgets::Block::bordered()
+}

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -28,3 +28,10 @@ ratatui = { version = "0.26", optional = true, default-features = false, feature
 termini = "1.0"
 once_cell = "1.21"
 log = "~0.4"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "backend_performance"
+harness = false

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -13,6 +13,8 @@ homepage.workspace = true
 
 [features]
 default = ["crossterm"]
+ratatui-migration = ["ratatui"]
+crossterm = ["dep:crossterm"]
 
 [dependencies]
 helix-view = { path = "../helix-view", features = ["term"] }
@@ -22,6 +24,7 @@ bitflags.workspace = true
 cassowary = "0.3"
 unicode-segmentation.workspace = true
 crossterm = { version = "0.28", optional = true }
+ratatui = { version = "0.26", optional = true, default-features = false, features = ["crossterm"] }
 termini = "1.0"
 once_cell = "1.21"
 log = "~0.4"

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 
 [features]
 default = ["crossterm"]
-ratatui-migration = ["ratatui"]
+ratatui-migration = ["ratatui", "crossterm"]
 crossterm = ["dep:crossterm"]
 
 [dependencies]

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -35,3 +35,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "backend_performance"
 harness = false
+
+[[bench]]
+name = "buffer_vs_ratatui"
+harness = false

--- a/helix-tui/benches/backend_performance.rs
+++ b/helix-tui/benches/backend_performance.rs
@@ -1,0 +1,200 @@
+//! Performance benchmarks for backend implementations
+//! 
+//! This module benchmarks the performance of different backend implementations
+//! to ensure the ratatui adapter doesn't introduce significant overhead.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use helix_tui::{
+    backend::{Backend, TestBackend},
+    buffer::Cell,
+    terminal::Config,
+};
+use helix_view::graphics::{Color, CursorKind, Modifier, Style, UnderlineStyle};
+
+#[cfg(feature = "ratatui-migration")]
+use helix_tui::backend::RatatuiBackendAdapter;
+
+/// Create a test cell with styling for benchmarks
+fn create_styled_cell(symbol: &str, fg: Color, bg: Color) -> Cell {
+    Cell {
+        symbol: symbol.to_string(),
+        fg,
+        bg,
+        modifier: Modifier::BOLD | Modifier::ITALIC,
+        underline_color: Color::Cyan,
+        underline_style: UnderlineStyle::Line,
+    }
+}
+
+/// Benchmark native helix-tui TestBackend performance
+fn bench_native_backend(c: &mut Criterion) {
+    c.bench_function("native_backend_operations", |b| {
+        b.iter(|| {
+            let mut backend = TestBackend::new(80, 24);
+            let config1 = Config { enable_mouse_capture: false };
+            let config2 = Config { enable_mouse_capture: false };
+            
+            // Basic operations
+            black_box(backend.claim(config1).unwrap());
+            black_box(backend.hide_cursor().unwrap());
+            black_box(backend.show_cursor(CursorKind::Block).unwrap());
+            black_box(backend.set_cursor(10, 5).unwrap());
+            black_box(backend.clear().unwrap());
+            black_box(backend.flush().unwrap());
+            black_box(backend.restore(config2).unwrap());
+        })
+    });
+}
+
+/// Benchmark drawing performance with native backend
+fn bench_native_drawing(c: &mut Criterion) {
+    c.bench_function("native_backend_drawing", |b| {
+        let mut backend = TestBackend::new(100, 30);
+        
+        b.iter(|| {
+            // Create test content
+            let cells: Vec<(u16, u16, Cell)> = (0..100)
+                .flat_map(|x| {
+                    (0..30).map(move |y| {
+                        (x, y, create_styled_cell(
+                            &(((x + y) % 26 + 65) as u8 as char).to_string(),
+                            Color::Indexed(((x + y) % 256) as u8),
+                            Color::Reset,
+                        ))
+                    })
+                })
+                .collect();
+            
+            let cell_refs: Vec<(u16, u16, &Cell)> = cells.iter()
+                .map(|(x, y, cell)| (*x, *y, cell))
+                .collect();
+            
+            black_box(backend.draw(cell_refs.into_iter()).unwrap());
+            black_box(backend.flush().unwrap());
+        })
+    });
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Benchmark ratatui adapter performance
+fn bench_ratatui_adapter(c: &mut Criterion) {
+    c.bench_function("ratatui_adapter_operations", |b| {
+        b.iter(|| {
+            let ratatui_backend = ratatui::backend::TestBackend::new(80, 24);
+            let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+            let config1 = Config { enable_mouse_capture: false };
+            let config2 = Config { enable_mouse_capture: false };
+            
+            // Basic operations
+            black_box(adapter.claim(config1).unwrap());
+            black_box(adapter.hide_cursor().unwrap());
+            black_box(adapter.show_cursor(CursorKind::Block).unwrap());
+            black_box(adapter.set_cursor(10, 5).unwrap());
+            black_box(adapter.clear().unwrap());
+            black_box(adapter.flush().unwrap());
+            black_box(adapter.restore(config2).unwrap());
+        })
+    });
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Benchmark drawing performance with ratatui adapter
+fn bench_ratatui_drawing(c: &mut Criterion) {
+    c.bench_function("ratatui_adapter_drawing", |b| {
+        let ratatui_backend = ratatui::backend::TestBackend::new(100, 30);
+        let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+        
+        b.iter(|| {
+            // Create test content
+            let cells: Vec<(u16, u16, Cell)> = (0..100)
+                .flat_map(|x| {
+                    (0..30).map(move |y| {
+                        (x, y, create_styled_cell(
+                            &(((x + y) % 26 + 65) as u8 as char).to_string(),
+                            Color::Indexed(((x + y) % 256) as u8),
+                            Color::Reset,
+                        ))
+                    })
+                })
+                .collect();
+            
+            let cell_refs: Vec<(u16, u16, &Cell)> = cells.iter()
+                .map(|(x, y, cell)| (*x, *y, cell))
+                .collect();
+            
+            black_box(adapter.draw(cell_refs.into_iter()).unwrap());
+            black_box(adapter.flush().unwrap());
+        })
+    });
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Benchmark conversion overhead
+fn bench_conversion_overhead(c: &mut Criterion) {
+    use helix_tui::compat::ratatui_compat::{convert_cell, convert_color, convert_style, convert_rect};
+    use helix_view::graphics::Rect;
+    
+    c.bench_function("conversion_functions", |b| {
+        let cell = create_styled_cell("A", Color::Red, Color::Blue);
+        let style = Style::default().fg(Color::Green).bg(Color::Yellow).add_modifier(Modifier::BOLD);
+        let rect = Rect::new(10, 20, 80, 40);
+        let color = Color::Rgb(128, 64, 192);
+        
+        b.iter(|| {
+            black_box(convert_cell(&cell));
+            black_box(convert_style(style));
+            black_box(convert_rect(rect));
+            black_box(convert_color(color));
+        })
+    });
+}
+
+/// Benchmark buffer operations
+fn bench_buffer_operations(c: &mut Criterion) {
+    c.bench_function("buffer_large_content", |b| {
+        let mut backend = TestBackend::new(200, 100);
+        
+        b.iter(|| {
+            // Create large buffer content
+            let cells: Vec<(u16, u16, Cell)> = (0..200)
+                .flat_map(|x| {
+                    (0..100).map(move |y| {
+                        (x, y, create_styled_cell(
+                            &(((x + y) % 26 + 65) as u8 as char).to_string(),
+                            Color::Indexed(((x + y) % 256) as u8),
+                            Color::Reset,
+                        ))
+                    })
+                })
+                .collect();
+            
+            let cell_refs: Vec<(u16, u16, &Cell)> = cells.iter()
+                .map(|(x, y, cell)| (*x, *y, cell))
+                .collect();
+            
+            black_box(backend.draw(cell_refs.into_iter()).unwrap());
+        })
+    });
+}
+
+// Configure benchmarks based on available features
+#[cfg(feature = "ratatui-migration")]
+criterion_group!(
+    benches,
+    bench_native_backend,
+    bench_native_drawing,
+    bench_ratatui_adapter,
+    bench_ratatui_drawing,
+    bench_conversion_overhead,
+    bench_buffer_operations
+);
+
+#[cfg(not(feature = "ratatui-migration"))]
+criterion_group!(
+    benches,
+    bench_native_backend,
+    bench_native_drawing,
+    bench_buffer_operations
+);
+
+criterion_main!(benches);

--- a/helix-tui/benches/buffer_vs_ratatui.rs
+++ b/helix-tui/benches/buffer_vs_ratatui.rs
@@ -1,0 +1,266 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use helix_tui::buffer::{Buffer as HelixBuffer};
+use helix_view::graphics::{Color, Modifier, Rect, Style};
+
+#[cfg(feature = "ratatui-migration")]
+use ratatui::{buffer::Buffer as RatatuiBuffer, buffer::Cell as RatatuiCell};
+#[cfg(feature = "ratatui-migration")]
+use ratatui::{style::Style as RatatuiStyle, style::Color as RatatuiColor, layout::Rect as RatatuiRect};
+
+fn create_test_content() -> Vec<&'static str> {
+    vec![
+        "┌─ HELIX EDITOR ─────────────────────────────┐",
+        "│ fn main() {                               │",
+        "│     let mut text = String::from(\"Hello\"); │",
+        "│     text.push_str(\", World!\");            │",
+        "│     println!(\"{}\", text);                 │",
+        "│ }                                         │",
+        "│                                           │",
+        "│ // Comments with Unicode: 🦀 Rust         │",
+        "│ // CJK characters: 日本語, 中文, 한글      │",
+        "│ // Math symbols: ∀x∈ℝ, ∃y: x²+y²=1       │",
+        "└───────────────────────────────────────────┘",
+    ]
+}
+
+/// Benchmark helix buffer's diff algorithm - CORE PERFORMANCE FEATURE
+fn bench_helix_buffer_diff(c: &mut Criterion) {
+    let area = Rect::new(0, 0, 50, 20);
+    let content = create_test_content();
+    
+    // Create two similar buffers with small differences (realistic editor scenario)
+    let mut buffer1 = HelixBuffer::with_lines(content.clone());
+    buffer1.resize(area);
+    
+    let mut buffer2 = HelixBuffer::with_lines(content);
+    buffer2.resize(area);
+    
+    // Make small changes (simulates typical editing)
+    buffer2.set_string(10, 1, "modified", Style::default().fg(Color::Red));
+    buffer2.set_string(15, 3, "changed", Style::default().bg(Color::Yellow));
+    
+    c.bench_function("helix_buffer_diff", |b| {
+        b.iter(|| {
+            let diff = buffer1.diff(black_box(&buffer2));
+            black_box(diff)
+        })
+    });
+}
+
+/// Benchmark helix buffer's merge operation - ESSENTIAL for overlay composition
+fn bench_helix_buffer_merge(c: &mut Criterion) {
+    let base_area = Rect::new(0, 0, 50, 20);
+    let overlay_area = Rect::new(10, 5, 20, 8);
+    
+    c.bench_function("helix_buffer_merge", |b| {
+        b.iter(|| {
+            let mut base = HelixBuffer::with_lines(create_test_content());
+            base.resize(base_area);
+            
+            let mut overlay = HelixBuffer::empty(overlay_area);
+            overlay.set_string(0, 0, "POPUP CONTENT", Style::default().bg(Color::Blue));
+            overlay.set_string(0, 1, "More content", Style::default().fg(Color::White));
+            
+            base.merge(black_box(&overlay));
+            black_box(base)
+        })
+    });
+}
+
+/// Benchmark helix buffer's advanced text operations - UNIQUE TO HELIX
+fn bench_helix_text_operations(c: &mut Criterion) {
+    let area = Rect::new(0, 0, 100, 30);
+    
+    c.bench_function("helix_buffer_set_spans", |b| {
+        b.iter(|| {
+            let mut buffer = HelixBuffer::empty(area);
+            
+            // Complex multi-style text (status line simulation)
+            let spans = helix_tui::text::Spans::from(vec![
+                helix_tui::text::Span::styled("NORMAL", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                helix_tui::text::Span::raw(" "),
+                helix_tui::text::Span::styled("main.rs", Style::default().fg(Color::Cyan)),
+                helix_tui::text::Span::raw(" "),
+                helix_tui::text::Span::styled("[+]", Style::default().fg(Color::Yellow)),
+                helix_tui::text::Span::raw(" Line 42:18 "),
+                helix_tui::text::Span::styled("UTF-8", Style::default().fg(Color::Gray)),
+            ]);
+            
+            buffer.set_spans(0, 0, &spans, 50);
+            black_box(buffer)
+        })
+    });
+    
+    c.bench_function("helix_buffer_set_string_truncated", |b| {
+        b.iter(|| {
+            let mut buffer = HelixBuffer::empty(area);
+            let long_text = "This is a very long line that needs to be truncated with ellipsis at the end to fit in the available space";
+            
+            // Simulates file path truncation in status bar
+            buffer.set_string_truncated(
+                0, 0,
+                long_text,
+                30,
+                |_| Style::default().fg(Color::LightBlue),
+                true,  // ellipsis
+                false, // truncate_end
+            );
+            black_box(buffer)
+        })
+    });
+}
+
+/// Benchmark unicode and multi-width character handling - CRITICAL for international use
+fn bench_helix_unicode_handling(c: &mut Criterion) {
+    let area = Rect::new(0, 0, 80, 25);
+    
+    c.bench_function("helix_buffer_unicode_heavy", |b| {
+        b.iter(|| {
+            let mut buffer = HelixBuffer::empty(area);
+            
+            // Mix of different Unicode categories
+            let unicode_lines = vec![
+                "🦀 Rust: fn main() { println!(\"Hello, 世界!\"); }",
+                "🐍 Python: def main(): print(\"你好, World!\")",
+                "🎯 Target: 目標達成！ Achievement unlocked 🏆",
+                "📊 Data: ∑(xᵢ) = μ ± σ² for i∈[1,n] ∀n∈ℕ",
+                "🌍 Unicode: العربية, עברית, हिन्दी, ελληνικά, русский",
+                "🎨 Emoji: 😀😃😄😁😆😅🤣😂🙂🙃😉😊😇",
+                "🔤 Combining: é, ñ, ü, ø, å (café naïveté résumé)",
+            ];
+            
+            for (y, line) in unicode_lines.iter().enumerate() {
+                buffer.set_string(0, y as u16, line, Style::default());
+            }
+            black_box(buffer)
+        })
+    });
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Benchmark ratatui buffer operations for comparison
+fn bench_ratatui_buffer_basic(c: &mut Criterion) {
+    let area = RatatuiRect { x: 0, y: 0, width: 50, height: 20 };
+    
+    c.bench_function("ratatui_buffer_basic_ops", |b| {
+        b.iter(|| {
+            let mut buffer = RatatuiBuffer::empty(area);
+            
+            // Basic operations that ratatui CAN do
+            buffer.set_string(0, 0, "Hello, World!", RatatuiStyle::default());
+            buffer.set_string(0, 1, "Line 2", RatatuiStyle::default().fg(RatatuiColor::Red));
+            buffer.set_string(0, 2, "Line 3", RatatuiStyle::default().bg(RatatuiColor::Blue));
+            
+            black_box(buffer)
+        })
+    });
+    
+    // NOTE: Cannot benchmark diff() or merge() - these methods don't exist in ratatui!
+}
+
+/// Benchmark memory usage patterns
+fn bench_helix_buffer_memory(c: &mut Criterion) {
+    c.bench_function("helix_buffer_large_creation", |b| {
+        b.iter(|| {
+            // Large terminal buffer (4K display)
+            let buffer = HelixBuffer::empty(Rect::new(0, 0, 200, 100));
+            black_box(buffer)
+        })
+    });
+    
+    c.bench_function("helix_buffer_repeated_modifications", |b| {
+        let area = Rect::new(0, 0, 80, 24);
+        
+        b.iter(|| {
+            let mut buffer = HelixBuffer::empty(area);
+            // Simulates rapid editing operations
+            for i in 0..100 {
+                let x = (i % 80) as u16;
+                let y = (i / 80) as u16;
+                if let Some(cell) = buffer.get_mut(x, y) {
+                    cell.set_char((b'A' + (i % 26) as u8) as char)
+                        .set_fg(Color::Indexed((i % 255) as u8))
+                        .set_style(Style::default().add_modifier(Modifier::BOLD));
+                }
+            }
+            black_box(buffer)
+        })
+    });
+}
+
+/// Demonstrate helix buffer's sophisticated diff algorithm
+fn bench_realistic_editor_scenario(c: &mut Criterion) {
+    c.bench_function("realistic_editor_diff_scenario", |b| {
+        let area = Rect::new(0, 0, 120, 40);
+        
+        b.iter(|| {
+            // Simulate before: editing a Rust file
+            let before_content = vec![
+                "use std::collections::HashMap;",
+                "",
+                "fn main() {",
+                "    let mut map = HashMap::new();",
+                "    map.insert(\"key\", \"value\");",
+                "    println!(\"{:?}\", map);",
+                "}",
+                "",
+                "// TODO: Add error handling",
+                "// TODO: Add documentation",
+            ];
+            
+            // Simulate after: user made several edits
+            let after_content = vec![
+                "use std::collections::HashMap;",
+                "use std::io::{self, Write};",  // Added import
+                "",
+                "fn main() -> Result<(), io::Error> {",  // Changed signature
+                "    let mut map = HashMap::new();",
+                "    map.insert(\"greeting\", \"Hello, World!\");",  // Modified
+                "    println!(\"{:?}\", map);",
+                "    Ok(())",  // Added return
+                "}",
+                "",
+                "// DONE: Add error handling",  // Modified
+                "// TODO: Add documentation",
+            ];
+            
+            let mut before_buffer = HelixBuffer::with_lines(before_content);
+            before_buffer.resize(area);
+            
+            let mut after_buffer = HelixBuffer::with_lines(after_content);
+            after_buffer.resize(area);
+            
+            // This diff operation is what makes helix buffer special!
+            let diff = before_buffer.diff(&after_buffer);
+            
+            // Verify the diff algorithm found the minimal changes
+            // In a real editor, this translates to efficient terminal updates
+            black_box(diff.len())
+        })
+    });
+}
+
+#[cfg(feature = "ratatui-migration")]
+criterion_group!(
+    benches,
+    bench_helix_buffer_diff,
+    bench_helix_buffer_merge,
+    bench_helix_text_operations,
+    bench_helix_unicode_handling,
+    bench_ratatui_buffer_basic,
+    bench_helix_buffer_memory,
+    bench_realistic_editor_scenario
+);
+
+#[cfg(not(feature = "ratatui-migration"))]
+criterion_group!(
+    benches,
+    bench_helix_buffer_diff,
+    bench_helix_buffer_merge,
+    bench_helix_text_operations,
+    bench_helix_unicode_handling,
+    bench_helix_buffer_memory,
+    bench_realistic_editor_scenario
+);
+
+criterion_main!(benches);

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -14,6 +14,11 @@ pub use self::crossterm::CrosstermBackend;
 mod test;
 pub use self::test::TestBackend;
 
+#[cfg(feature = "ratatui-migration")]
+mod ratatui;
+#[cfg(feature = "ratatui-migration")]
+pub use self::ratatui::adapter::RatatuiBackendAdapter;
+
 /// Representation of a terminal backend.
 pub trait Backend {
     /// Claims the terminal for TUI use.

--- a/helix-tui/src/backend/ratatui.rs
+++ b/helix-tui/src/backend/ratatui.rs
@@ -55,24 +55,87 @@ pub mod adapter {
     where
         B: ratatui::backend::Backend,
     {
-        fn claim(&mut self, _config: Config) -> Result<(), io::Error> {
-            // For ratatui, claiming is handled by the terminal setup
-            // This is a no-op for compatibility
+        fn claim(&mut self, config: Config) -> Result<(), io::Error> {
+            // For ratatui backends, we need to handle terminal setup manually
+            // since ratatui doesn't expose claim/restore methods
+            use crossterm::{
+                terminal::{enable_raw_mode, EnterAlternateScreen},
+                event::{EnableFocusChange, EnableBracketedPaste, EnableMouseCapture},
+                execute,
+            };
+            
+            enable_raw_mode()?;
+            let mut stdout = std::io::stdout();
+            execute!(stdout, EnterAlternateScreen, EnableFocusChange)?;
+            
+            // Enable bracketed paste
+            if let Err(err) = execute!(stdout, EnableBracketedPaste) {
+                if err.kind() != io::ErrorKind::Unsupported {
+                    return Err(err);
+                }
+            }
+            
+            // Enable mouse capture if requested
+            if config.enable_mouse_capture {
+                execute!(stdout, EnableMouseCapture)?;
+            }
+            
             Ok(())
         }
         
-        fn reconfigure(&mut self, _config: Config) -> Result<(), io::Error> {
-            // Configuration changes are handled at the terminal level
+        fn reconfigure(&mut self, config: Config) -> Result<(), io::Error> {
+            // Handle mouse capture configuration changes
+            use crossterm::{event::{EnableMouseCapture, DisableMouseCapture}, execute};
+            
+            let mut stdout = std::io::stdout();
+            if config.enable_mouse_capture {
+                execute!(stdout, EnableMouseCapture)?;
+            } else {
+                execute!(stdout, DisableMouseCapture)?;
+            }
+            
             Ok(())
         }
         
-        fn restore(&mut self, _config: Config) -> Result<(), io::Error> {
-            // Restoration is handled by the terminal cleanup
+        fn restore(&mut self, config: Config) -> Result<(), io::Error> {
+            // Restore terminal to normal state
+            use crossterm::{
+                terminal::{disable_raw_mode, LeaveAlternateScreen},
+                event::{DisableFocusChange, DisableBracketedPaste, DisableMouseCapture},
+                execute,
+            };
+            
+            let mut stdout = std::io::stdout();
+            
+            // Disable mouse capture if it was enabled
+            if config.enable_mouse_capture {
+                execute!(stdout, DisableMouseCapture)?;
+            }
+            
+            // Disable other features
+            execute!(stdout, DisableBracketedPaste)?;
+            execute!(stdout, DisableFocusChange, LeaveAlternateScreen)?;
+            
+            disable_raw_mode()?;
             Ok(())
         }
         
         fn force_restore() -> Result<(), io::Error> {
-            // Force restore is a terminal-level operation
+            // Force restore - ignore errors and restore as much as possible
+            use crossterm::{
+                terminal::{disable_raw_mode, LeaveAlternateScreen},
+                event::{DisableFocusChange, DisableBracketedPaste, DisableMouseCapture},
+                execute,
+            };
+            
+            let mut stdout = std::io::stdout();
+            
+            // Ignore individual errors but try to restore everything
+            let _ = execute!(stdout, DisableMouseCapture);
+            let _ = execute!(stdout, DisableBracketedPaste);
+            let _ = execute!(stdout, DisableFocusChange, LeaveAlternateScreen);
+            let _ = disable_raw_mode();
+            
             Ok(())
         }
         

--- a/helix-tui/src/backend/ratatui.rs
+++ b/helix-tui/src/backend/ratatui.rs
@@ -1,0 +1,202 @@
+//! Ratatui backend adapter that implements the helix-tui Backend trait
+//! using ratatui's backend implementations
+
+#[cfg(feature = "ratatui-migration")]
+pub mod adapter {
+    use crate::backend::Backend;
+    use crate::buffer::Cell;
+    use crate::compat::ratatui_compat::{convert_cell, convert_rect_back};
+    use crate::terminal::Config;
+    use helix_view::graphics::{CursorKind, Rect};
+    use std::io;
+    
+    /// Adapter that wraps a ratatui backend to implement helix-tui Backend trait
+    pub struct RatatuiBackendAdapter<B>
+    where
+        B: ratatui::backend::Backend,
+    {
+        backend: B,
+        /// Buffer to temporarily hold ratatui cells for conversion
+        ratatui_buffer: ratatui::buffer::Buffer,
+    }
+    
+    impl<B> RatatuiBackendAdapter<B>
+    where
+        B: ratatui::backend::Backend,
+    {
+        pub fn new(backend: B) -> io::Result<Self> {
+            let size = backend.size()?;
+            let ratatui_buffer = ratatui::buffer::Buffer::empty(size);
+            Ok(Self {
+                backend,
+                ratatui_buffer,
+            })
+        }
+        
+        pub fn inner(&self) -> &B {
+            &self.backend
+        }
+        
+        pub fn inner_mut(&mut self) -> &mut B {
+            &mut self.backend
+        }
+        
+        /// Resize the internal ratatui buffer to match terminal size
+        fn sync_buffer_size(&mut self) -> io::Result<()> {
+            let size = self.backend.size()?;
+            if self.ratatui_buffer.area != size {
+                self.ratatui_buffer.resize(size);
+            }
+            Ok(())
+        }
+    }
+    
+    impl<B> Backend for RatatuiBackendAdapter<B>
+    where
+        B: ratatui::backend::Backend,
+    {
+        fn claim(&mut self, _config: Config) -> Result<(), io::Error> {
+            // For ratatui, claiming is handled by the terminal setup
+            // This is a no-op for compatibility
+            Ok(())
+        }
+        
+        fn reconfigure(&mut self, _config: Config) -> Result<(), io::Error> {
+            // Configuration changes are handled at the terminal level
+            Ok(())
+        }
+        
+        fn restore(&mut self, _config: Config) -> Result<(), io::Error> {
+            // Restoration is handled by the terminal cleanup
+            Ok(())
+        }
+        
+        fn force_restore() -> Result<(), io::Error> {
+            // Force restore is a terminal-level operation
+            Ok(())
+        }
+        
+        fn draw<'a, I>(&mut self, content: I) -> Result<(), io::Error>
+        where
+            I: Iterator<Item = (u16, u16, &'a Cell)>,
+        {
+            // Ensure buffer size matches backend size
+            self.sync_buffer_size()?;
+            
+            // Convert helix-tui cells to ratatui cells and update buffer
+            for (x, y, helix_cell) in content {
+                // Use ratatui's buffer coordinate system to set cells
+                let ratatui_cell = convert_cell(helix_cell);
+                if x < self.ratatui_buffer.area.width && y < self.ratatui_buffer.area.height {
+                    let index = (y as usize * self.ratatui_buffer.area.width as usize) + x as usize;
+                    if index < self.ratatui_buffer.content.len() {
+                        self.ratatui_buffer.content[index] = ratatui_cell;
+                    }
+                }
+            }
+            
+            // Draw the buffer content through ratatui backend
+            let buffer_content = self.ratatui_buffer.content.iter()
+                .enumerate()
+                .map(|(i, cell)| {
+                    let x = (i % self.ratatui_buffer.area.width as usize) as u16;
+                    let y = (i / self.ratatui_buffer.area.width as usize) as u16;
+                    (x, y, cell)
+                });
+            
+            self.backend.draw(buffer_content)
+        }
+        
+        fn hide_cursor(&mut self) -> Result<(), io::Error> {
+            self.backend.hide_cursor()
+        }
+        
+        fn show_cursor(&mut self, kind: CursorKind) -> Result<(), io::Error> {
+            // ratatui's show_cursor doesn't take parameters, so we ignore the kind
+            // This is a limitation of the compatibility layer
+            match kind {
+                CursorKind::Hidden => self.backend.hide_cursor(),
+                _ => self.backend.show_cursor(),
+            }
+        }
+        
+        fn get_cursor(&mut self) -> Result<(u16, u16), io::Error> {
+            self.backend.get_cursor()
+        }
+        
+        fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error> {
+            self.backend.set_cursor(x, y)
+        }
+        
+        fn clear(&mut self) -> Result<(), io::Error> {
+            self.backend.clear()
+        }
+        
+        fn size(&self) -> Result<Rect, io::Error> {
+            let ratatui_size = self.backend.size()?;
+            Ok(convert_rect_back(ratatui_size))
+        }
+        
+        fn flush(&mut self) -> Result<(), io::Error> {
+            self.backend.flush()
+        }
+    }
+    
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use ratatui::backend::TestBackend;
+        
+        #[test]
+        fn test_ratatui_adapter_creation() {
+            let ratatui_backend = TestBackend::new(80, 24);
+            let adapter = RatatuiBackendAdapter::new(ratatui_backend);
+            assert!(adapter.is_ok());
+            
+            let adapter = adapter.unwrap();
+            let size = adapter.size().unwrap();
+            assert_eq!(size.width, 80);
+            assert_eq!(size.height, 24);
+        }
+        
+        #[test]
+        fn test_backend_operations() {
+            let ratatui_backend = TestBackend::new(40, 20);
+            let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+            
+            // Test basic operations don't panic
+            assert!(adapter.claim(Config { enable_mouse_capture: false }).is_ok());
+            assert!(adapter.clear().is_ok());
+            assert!(adapter.flush().is_ok());
+            assert!(adapter.hide_cursor().is_ok());
+            assert!(adapter.show_cursor(CursorKind::Block).is_ok());
+            
+            // Test size
+            let size = adapter.size().unwrap();
+            assert_eq!(size.width, 40);
+            assert_eq!(size.height, 20);
+        }
+        
+        #[test]
+        fn test_cursor_operations() {
+            let ratatui_backend = TestBackend::new(30, 15);
+            let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+            
+            // Test cursor positioning
+            assert!(adapter.set_cursor(10, 5).is_ok());
+            let (x, y) = adapter.get_cursor().unwrap();
+            assert_eq!(x, 10);
+            assert_eq!(y, 5);
+            
+            // Test cursor kinds
+            assert!(adapter.show_cursor(CursorKind::Bar).is_ok());
+            assert!(adapter.show_cursor(CursorKind::Underline).is_ok());
+            assert!(adapter.show_cursor(CursorKind::Hidden).is_ok());
+        }
+    }
+}
+
+#[cfg(not(feature = "ratatui-migration"))]
+pub mod adapter {
+    //! Stub module when ratatui migration feature is disabled
+}

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -382,21 +382,34 @@ pub mod ratatui_compat {
     ) where 
         W: ratatui::widgets::Widget,
     {
-        // Create a temporary ratatui buffer
+        // Create a temporary ratatui buffer with the full surface area to avoid coordinate issues
+        let surface_area = surface.area;
+        let ratatui_surface_area = convert_rect(surface_area);
+        let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_surface_area);
+        
+        // Convert the target area
         let ratatui_area = convert_rect(area);
-        let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
         
         // Render the ratatui widget to the ratatui buffer
         widget.render(ratatui_area, &mut ratatui_buffer);
         
-        // Copy the rendered content back to the helix buffer
-        for y in ratatui_area.top()..ratatui_area.bottom() {
-            for x in ratatui_area.left()..ratatui_area.right() {
-                // ratatui buffer.get() returns &Cell directly (not Option)
-                let ratatui_cell = ratatui_buffer.get(x, y);
-                if let Some(helix_cell_pos) = surface.get_mut(x, y) {
-                    let helix_cell = convert_cell_back(ratatui_cell);
-                    *helix_cell_pos = helix_cell;
+        // Only copy the cells within the target area, using absolute coordinates
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                // Check bounds to prevent out-of-bounds access
+                if x < surface_area.right() && y < surface_area.bottom() {
+                    let ratatui_cell = ratatui_buffer.get(x, y);
+                    if let Some(helix_cell_pos) = surface.get_mut(x, y) {
+                        let mut helix_cell = convert_cell_back(ratatui_cell);
+                        
+                        // If the original helix cell has a background but the ratatui cell doesn't,
+                        // preserve the original background to maintain popup styling
+                        if helix_cell.bg == Color::Reset && helix_cell_pos.bg != Color::Reset {
+                            helix_cell.bg = helix_cell_pos.bg;
+                        }
+                        
+                        *helix_cell_pos = helix_cell;
+                    }
                 }
             }
         }

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -212,8 +212,18 @@ pub mod ratatui_compat {
         ratatui::text::Line::from(ratatui_spans)
     }
     
-    /// Convert helix Text to ratatui Text for Paragraph widgets
-    pub fn convert_text<'a>(helix_text: &'a crate::text::Text<'a>) -> ratatui::text::Text<'a> {
+    /// Convert helix Text to ratatui Text for Paragraph widgets (consuming version)
+    pub fn convert_text<'a>(helix_text: crate::text::Text<'a>) -> ratatui::text::Text<'a> {
+        // Convert each line (Spans) to ratatui Line
+        let ratatui_lines: Vec<ratatui::text::Line> = helix_text.lines
+            .into_iter()
+            .map(|spans| convert_spans_to_line(spans))
+            .collect();
+        ratatui::text::Text::from(ratatui_lines)
+    }
+    
+    /// Convert helix Text to ratatui Text for Paragraph widgets (borrowing version)
+    pub fn convert_text_ref<'a>(helix_text: &'a crate::text::Text<'a>) -> ratatui::text::Text<'a> {
         // Convert each line (Spans) to ratatui Line
         let ratatui_lines: Vec<ratatui::text::Line> = helix_text.lines
             .iter()
@@ -249,6 +259,63 @@ pub mod ratatui_compat {
             crate::widgets::BorderType::Double => ratatui::widgets::BorderType::Double,
             crate::widgets::BorderType::Thick => ratatui::widgets::BorderType::Thick,
         }
+    }
+    
+    /// Convert helix Block to ratatui Block for widgets
+    pub fn convert_block<'a>(block: crate::widgets::Block<'a>) -> ratatui::widgets::Block<'a> {
+        let mut ratatui_block = ratatui::widgets::Block::new();
+        
+        // Convert borders
+        ratatui_block = ratatui_block.borders(convert_borders(block.get_borders()));
+        
+        // Convert border type
+        ratatui_block = ratatui_block.border_type(convert_border_type(block.get_border_type()));
+        
+        // Convert style
+        ratatui_block = ratatui_block.style(convert_style(block.get_style()));
+        
+        // Convert titles (left, center, right)
+        if let Some(title) = block.get_title() {
+            ratatui_block = ratatui_block.title(convert_spans_to_line(title.clone()));
+        }
+        
+        ratatui_block
+    }
+    
+    /// Convert helix Constraint to ratatui Constraint
+    pub fn convert_constraint(constraint: crate::layout::Constraint) -> ratatui::layout::Constraint {
+        match constraint {
+            crate::layout::Constraint::Length(n) => ratatui::layout::Constraint::Length(n),
+            crate::layout::Constraint::Max(n) => ratatui::layout::Constraint::Max(n),
+            crate::layout::Constraint::Min(n) => ratatui::layout::Constraint::Min(n),
+            crate::layout::Constraint::Percentage(n) => ratatui::layout::Constraint::Percentage(n),
+            crate::layout::Constraint::Ratio(a, b) => ratatui::layout::Constraint::Ratio(a, b),
+        }
+    }
+    
+    /// Convert slice of helix Constraints to ratatui Constraints
+    pub fn convert_constraints(constraints: &[crate::layout::Constraint]) -> Vec<ratatui::layout::Constraint> {
+        constraints.iter().map(|c| convert_constraint(*c)).collect()
+    }
+    
+    /// Convert helix TableState to ratatui TableState
+    pub fn convert_table_state(state: &crate::widgets::TableState) -> ratatui::widgets::TableState {
+        let mut ratatui_state = ratatui::widgets::TableState::default();
+        ratatui_state.select(state.selected);
+        // Note: ratatui TableState doesn't have a direct offset setter
+        // We'll need to use scroll_to methods for proper scrolling behavior
+        if let Some(selected) = state.selected {
+            // Use select to set both selected index and handle scrolling
+            ratatui_state.select(Some(selected));
+        }
+        ratatui_state
+    }
+    
+    /// Update helix TableState from ratatui TableState
+    pub fn update_table_state_from_ratatui(helix_state: &mut crate::widgets::TableState, ratatui_state: &ratatui::widgets::TableState) {
+        helix_state.selected = ratatui_state.selected();
+        // Note: ratatui TableState doesn't expose offset publicly
+        // This will be handled through the selection mechanism
     }
     
     /// Render a ratatui widget with buffer conversion

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -212,6 +212,16 @@ pub mod ratatui_compat {
         ratatui::text::Line::from(ratatui_spans)
     }
     
+    /// Convert helix Text to ratatui Text for Paragraph widgets
+    pub fn convert_text<'a>(helix_text: &'a crate::text::Text<'a>) -> ratatui::text::Text<'a> {
+        // Convert each line (Spans) to ratatui Line
+        let ratatui_lines: Vec<ratatui::text::Line> = helix_text.lines
+            .iter()
+            .map(|spans| convert_spans_to_line(spans.clone()))
+            .collect();
+        ratatui::text::Text::from(ratatui_lines)
+    }
+    
     /// Convert helix Borders to ratatui Borders (both use bitflags)
     pub fn convert_borders(borders: crate::widgets::Borders) -> ratatui::widgets::Borders {
         // Handle compound flags by checking each bit

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -1,0 +1,261 @@
+//! Compatibility layer for migrating from helix-tui to ratatui
+//!
+//! This module provides adapters and wrappers to gradually migrate
+//! from the helix-tui fork to the ratatui library while maintaining
+//! API compatibility with existing Helix code.
+
+#[cfg(feature = "ratatui-migration")]
+pub mod ratatui_compat {
+    use helix_view::graphics::{Color, Style, Rect, CursorKind};
+    
+    /// Convert helix graphics Color to ratatui Color
+    pub fn convert_color(color: Color) -> ratatui::style::Color {
+        match color {
+            Color::Reset => ratatui::style::Color::Reset,
+            Color::Black => ratatui::style::Color::Black,
+            Color::Red => ratatui::style::Color::Red,
+            Color::Green => ratatui::style::Color::Green,
+            Color::Yellow => ratatui::style::Color::Yellow,
+            Color::Blue => ratatui::style::Color::Blue,
+            Color::Magenta => ratatui::style::Color::Magenta,
+            Color::Cyan => ratatui::style::Color::Cyan,
+            Color::Gray => ratatui::style::Color::DarkGray,
+            Color::LightRed => ratatui::style::Color::LightRed,
+            Color::LightGreen => ratatui::style::Color::LightGreen,
+            Color::LightYellow => ratatui::style::Color::LightYellow,
+            Color::LightBlue => ratatui::style::Color::LightBlue,
+            Color::LightMagenta => ratatui::style::Color::LightMagenta,
+            Color::LightCyan => ratatui::style::Color::LightCyan,
+            Color::LightGray => ratatui::style::Color::Gray,
+            Color::White => ratatui::style::Color::White,
+            Color::Rgb(r, g, b) => ratatui::style::Color::Rgb(r, g, b),
+            Color::Indexed(i) => ratatui::style::Color::Indexed(i),
+        }
+    }
+    
+    /// Convert ratatui Color to helix graphics Color
+    pub fn convert_color_back(color: ratatui::style::Color) -> Color {
+        match color {
+            ratatui::style::Color::Reset => Color::Reset,
+            ratatui::style::Color::Black => Color::Black,
+            ratatui::style::Color::Red => Color::Red,
+            ratatui::style::Color::Green => Color::Green,
+            ratatui::style::Color::Yellow => Color::Yellow,
+            ratatui::style::Color::Blue => Color::Blue,
+            ratatui::style::Color::Magenta => Color::Magenta,
+            ratatui::style::Color::Cyan => Color::Cyan,
+            ratatui::style::Color::DarkGray => Color::Gray,
+            ratatui::style::Color::LightRed => Color::LightRed,
+            ratatui::style::Color::LightGreen => Color::LightGreen,
+            ratatui::style::Color::LightYellow => Color::LightYellow,
+            ratatui::style::Color::LightBlue => Color::LightBlue,
+            ratatui::style::Color::LightMagenta => Color::LightMagenta,
+            ratatui::style::Color::LightCyan => Color::LightCyan,
+            ratatui::style::Color::Gray => Color::LightGray,
+            ratatui::style::Color::White => Color::White,
+            ratatui::style::Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
+            ratatui::style::Color::Indexed(i) => Color::Indexed(i),
+        }
+    }
+    
+    /// Convert helix graphics Style to ratatui Style
+    pub fn convert_style(style: Style) -> ratatui::style::Style {
+        let mut ratatui_style = ratatui::style::Style::default();
+        
+        if let Some(fg) = style.fg {
+            ratatui_style = ratatui_style.fg(convert_color(fg));
+        }
+        
+        if let Some(bg) = style.bg {
+            ratatui_style = ratatui_style.bg(convert_color(bg));
+        }
+        
+        // Note: underline_color not available in ratatui 0.26
+        // Will be handled in future versions
+        
+        // Convert modifiers
+        ratatui_style = ratatui_style.add_modifier(convert_modifier(style.add_modifier));
+        
+        ratatui_style
+    }
+    
+    /// Convert helix graphics Rect to ratatui Rect
+    pub fn convert_rect(rect: Rect) -> ratatui::layout::Rect {
+        ratatui::layout::Rect {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+        }
+    }
+    
+    /// Convert ratatui Rect to helix graphics Rect
+    pub fn convert_rect_back(rect: ratatui::layout::Rect) -> Rect {
+        Rect {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+        }
+    }
+    
+    /// Convert helix CursorKind - will be handled at backend level
+    /// For now, just return the original kind for backend processing
+    pub fn convert_cursor_kind(kind: CursorKind) -> CursorKind {
+        // For now, pass through - backend will handle conversion
+        kind
+    }
+    
+    /// Convert helix-tui Cell to ratatui Cell
+    pub fn convert_cell(cell: &crate::buffer::Cell) -> ratatui::buffer::Cell {
+        let style = convert_style(cell.style());
+        let mut ratatui_cell = ratatui::buffer::Cell::default();
+        ratatui_cell.set_symbol(&cell.symbol);
+        ratatui_cell.set_style(style);
+        ratatui_cell
+    }
+    
+    /// Convert ratatui Cell to helix-tui Cell
+    pub fn convert_cell_back(cell: &ratatui::buffer::Cell) -> crate::buffer::Cell {
+        use helix_view::graphics::UnderlineStyle;
+        
+        crate::buffer::Cell {
+            symbol: cell.symbol().to_string(),
+            fg: cell.style().fg.map(convert_color_back).unwrap_or(Color::Reset),
+            bg: cell.style().bg.map(convert_color_back).unwrap_or(Color::Reset), 
+            modifier: convert_modifier_back(cell.style().add_modifier),
+            underline_color: Color::Reset, // Default fallback
+            underline_style: UnderlineStyle::Reset, // Default fallback
+        }
+    }
+    
+    /// Convert helix Modifier to ratatui Modifier
+    pub fn convert_modifier(modifier: helix_view::graphics::Modifier) -> ratatui::style::Modifier {
+        let mut result = ratatui::style::Modifier::empty();
+        
+        use helix_view::graphics::Modifier;
+        if modifier.contains(Modifier::BOLD) {
+            result |= ratatui::style::Modifier::BOLD;
+        }
+        if modifier.contains(Modifier::DIM) {
+            result |= ratatui::style::Modifier::DIM;
+        }
+        if modifier.contains(Modifier::ITALIC) {
+            result |= ratatui::style::Modifier::ITALIC;
+        }
+        // Note: helix doesn't have UNDERLINED modifier, but has underline_style
+        // This will be handled through the underline_style field conversion if needed
+        if modifier.contains(Modifier::SLOW_BLINK) {
+            result |= ratatui::style::Modifier::SLOW_BLINK;
+        }
+        if modifier.contains(Modifier::RAPID_BLINK) {
+            result |= ratatui::style::Modifier::RAPID_BLINK;
+        }
+        if modifier.contains(Modifier::REVERSED) {
+            result |= ratatui::style::Modifier::REVERSED;
+        }
+        if modifier.contains(Modifier::HIDDEN) {
+            result |= ratatui::style::Modifier::HIDDEN;
+        }
+        if modifier.contains(Modifier::CROSSED_OUT) {
+            result |= ratatui::style::Modifier::CROSSED_OUT;
+        }
+        
+        result
+    }
+    
+    /// Convert ratatui Modifier to helix Modifier
+    pub fn convert_modifier_back(modifier: ratatui::style::Modifier) -> helix_view::graphics::Modifier {
+        let mut result = helix_view::graphics::Modifier::empty();
+        
+        use helix_view::graphics::Modifier;
+        if modifier.contains(ratatui::style::Modifier::BOLD) {
+            result |= Modifier::BOLD;
+        }
+        if modifier.contains(ratatui::style::Modifier::DIM) {
+            result |= Modifier::DIM;
+        }
+        if modifier.contains(ratatui::style::Modifier::ITALIC) {
+            result |= Modifier::ITALIC;
+        }
+        // Note: ratatui UNDERLINED doesn't map directly to helix modifiers
+        // since helix uses underline_style field instead
+        if modifier.contains(ratatui::style::Modifier::SLOW_BLINK) {
+            result |= Modifier::SLOW_BLINK;
+        }
+        if modifier.contains(ratatui::style::Modifier::RAPID_BLINK) {
+            result |= Modifier::RAPID_BLINK;
+        }
+        if modifier.contains(ratatui::style::Modifier::REVERSED) {
+            result |= Modifier::REVERSED;
+        }
+        if modifier.contains(ratatui::style::Modifier::HIDDEN) {
+            result |= Modifier::HIDDEN;
+        }
+        if modifier.contains(ratatui::style::Modifier::CROSSED_OUT) {
+            result |= Modifier::CROSSED_OUT;
+        }
+        
+        result
+    }
+    
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use helix_view::graphics::{Modifier};
+        
+        #[test]
+        fn test_color_conversion() {
+            // Test basic colors
+            assert_eq!(convert_color(Color::Red), ratatui::style::Color::Red);
+            assert_eq!(convert_color(Color::Blue), ratatui::style::Color::Blue);
+            assert_eq!(convert_color(Color::Green), ratatui::style::Color::Green);
+            
+            // Test RGB
+            assert_eq!(convert_color(Color::Rgb(255, 128, 64)), ratatui::style::Color::Rgb(255, 128, 64));
+            
+            // Test indexed
+            assert_eq!(convert_color(Color::Indexed(42)), ratatui::style::Color::Indexed(42));
+            
+            // Test round-trip conversion
+            let original = Color::LightCyan;
+            let converted = convert_color(original);
+            let back = convert_color_back(converted);
+            assert_eq!(original, back);
+        }
+        
+        #[test]
+        fn test_style_conversion() {
+            let style = Style::default()
+                .fg(Color::Red)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD | Modifier::ITALIC);
+            
+            let ratatui_style = convert_style(style);
+            
+            assert_eq!(ratatui_style.fg, Some(ratatui::style::Color::Red));
+            assert_eq!(ratatui_style.bg, Some(ratatui::style::Color::Blue));
+            assert!(ratatui_style.add_modifier.contains(ratatui::style::Modifier::BOLD));
+            assert!(ratatui_style.add_modifier.contains(ratatui::style::Modifier::ITALIC));
+        }
+        
+        #[test] 
+        fn test_rect_conversion() {
+            let rect = Rect::new(10, 20, 80, 24);
+            let ratatui_rect = convert_rect(rect);
+            let back_rect = convert_rect_back(ratatui_rect);
+            
+            assert_eq!(rect, back_rect);
+            assert_eq!(ratatui_rect.x, 10);
+            assert_eq!(ratatui_rect.y, 20);
+            assert_eq!(ratatui_rect.width, 80);
+            assert_eq!(ratatui_rect.height, 24);
+        }
+    }
+}
+
+#[cfg(not(feature = "ratatui-migration"))]
+pub mod ratatui_compat {
+    //! Stub module when ratatui migration feature is disabled
+    //! This allows code to conditionally compile compatibility layers
+}

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -199,6 +199,76 @@ pub mod ratatui_compat {
         result
     }
     
+    /// Convert helix Spans to ratatui Line for Block titles
+    pub fn convert_spans_to_line(spans: crate::text::Spans<'_>) -> ratatui::text::Line<'_> {
+        // Convert helix Spans to ratatui Spans by converting each Span
+        let ratatui_spans: Vec<ratatui::text::Span> = spans.0
+            .into_iter()
+            .map(|span| {
+                let style = convert_style(span.style);
+                ratatui::text::Span::styled(span.content, style)
+            })
+            .collect();
+        ratatui::text::Line::from(ratatui_spans)
+    }
+    
+    /// Convert helix Borders to ratatui Borders (both use bitflags)
+    pub fn convert_borders(borders: crate::widgets::Borders) -> ratatui::widgets::Borders {
+        // Handle compound flags by checking each bit
+        let mut result = ratatui::widgets::Borders::empty();
+        if borders.contains(crate::widgets::Borders::TOP) {
+            result |= ratatui::widgets::Borders::TOP;
+        }
+        if borders.contains(crate::widgets::Borders::RIGHT) {
+            result |= ratatui::widgets::Borders::RIGHT;
+        }
+        if borders.contains(crate::widgets::Borders::BOTTOM) {
+            result |= ratatui::widgets::Borders::BOTTOM;
+        }
+        if borders.contains(crate::widgets::Borders::LEFT) {
+            result |= ratatui::widgets::Borders::LEFT;
+        }
+        result
+    }
+    
+    /// Convert helix BorderType to ratatui BorderType
+    pub fn convert_border_type(border_type: crate::widgets::BorderType) -> ratatui::widgets::BorderType {
+        match border_type {
+            crate::widgets::BorderType::Plain => ratatui::widgets::BorderType::Plain,
+            crate::widgets::BorderType::Rounded => ratatui::widgets::BorderType::Rounded,
+            crate::widgets::BorderType::Double => ratatui::widgets::BorderType::Double,
+            crate::widgets::BorderType::Thick => ratatui::widgets::BorderType::Thick,
+        }
+    }
+    
+    /// Render a ratatui widget with buffer conversion
+    pub fn render_ratatui_widget<W>(
+        widget: W,
+        area: Rect, 
+        surface: &mut crate::buffer::Buffer
+    ) where 
+        W: ratatui::widgets::Widget,
+    {
+        // Create a temporary ratatui buffer
+        let ratatui_area = convert_rect(area);
+        let mut ratatui_buffer = ratatui::buffer::Buffer::empty(ratatui_area);
+        
+        // Render the ratatui widget to the ratatui buffer
+        widget.render(ratatui_area, &mut ratatui_buffer);
+        
+        // Copy the rendered content back to the helix buffer
+        for y in ratatui_area.top()..ratatui_area.bottom() {
+            for x in ratatui_area.left()..ratatui_area.right() {
+                // ratatui buffer.get() returns &Cell directly (not Option)
+                let ratatui_cell = ratatui_buffer.get(x, y);
+                if let Some(helix_cell_pos) = surface.get_mut(x, y) {
+                    let helix_cell = convert_cell_back(ratatui_cell);
+                    *helix_cell_pos = helix_cell;
+                }
+            }
+        }
+    }
+    
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/helix-tui/src/compat.rs
+++ b/helix-tui/src/compat.rs
@@ -318,6 +318,62 @@ pub mod ratatui_compat {
         // This will be handled through the selection mechanism
     }
     
+    /// Convert helix table Cell to ratatui table Cell
+    pub fn convert_table_cell<'a>(cell: crate::widgets::Cell<'a>) -> ratatui::widgets::Cell<'a> {
+        // Use the conversion method we added to Cell
+        cell.to_ratatui_cell()
+    }
+    
+    /// Convert helix table Row to ratatui table Row
+    pub fn convert_table_row<'a>(row: crate::widgets::Row<'a>) -> ratatui::widgets::Row<'a> {
+        // Use the conversion method we added to Row
+        row.to_ratatui_row()
+    }
+    
+    /// Convert helix Table to ratatui Table
+    pub fn convert_table<'a>(table: crate::widgets::Table<'a>) -> ratatui::widgets::Table<'a> {
+        // Use the conversion method we added to Table
+        table.to_ratatui_table()
+    }
+    
+    /// Convert helix Wrap to ratatui Wrap
+    pub fn convert_wrap(wrap: crate::widgets::Wrap) -> ratatui::widgets::Wrap {
+        ratatui::widgets::Wrap { trim: wrap.trim }
+    }
+    
+    /// Render a Block widget using ratatui backend
+    pub fn render_block(block: crate::widgets::Block<'_>, area: Rect, surface: &mut crate::buffer::Buffer) {
+        // Convert helix Block to ratatui Block
+        let ratatui_block = convert_block(block);
+        render_ratatui_widget(ratatui_block, area, surface);
+    }
+    
+    /// Render a Paragraph widget using ratatui backend with reference text  
+    pub fn render_paragraph_ref(text: &crate::text::Text<'_>, wrap: Option<crate::widgets::Wrap>, area: Rect, surface: &mut crate::buffer::Buffer) {
+        // Convert helix text to ratatui text
+        let ratatui_text = convert_text_ref(text);
+        let mut paragraph = ratatui::widgets::Paragraph::new(ratatui_text);
+        
+        if let Some(wrap_config) = wrap {
+            paragraph = paragraph.wrap(convert_wrap(wrap_config));
+        }
+        
+        render_ratatui_widget(paragraph, area, surface);
+    }
+    
+    /// Render a Paragraph widget using ratatui backend with owned text
+    pub fn render_paragraph(text: crate::text::Text<'_>, wrap: Option<crate::widgets::Wrap>, area: Rect, surface: &mut crate::buffer::Buffer) {
+        // Convert helix text to ratatui text
+        let ratatui_text = convert_text(text);
+        let mut paragraph = ratatui::widgets::Paragraph::new(ratatui_text);
+        
+        if let Some(wrap_config) = wrap {
+            paragraph = paragraph.wrap(convert_wrap(wrap_config));
+        }
+        
+        render_ratatui_widget(paragraph, area, surface);
+    }
+    
     /// Render a ratatui widget with buffer conversion
     pub fn render_ratatui_widget<W>(
         widget: W,

--- a/helix-tui/src/lib.rs
+++ b/helix-tui/src/lib.rs
@@ -138,3 +138,6 @@ pub mod text;
 pub mod widgets;
 
 pub use self::terminal::{Terminal, TerminalOptions, Viewport};
+
+#[cfg(feature = "ratatui-migration")]
+pub use ratatui;

--- a/helix-tui/src/lib.rs
+++ b/helix-tui/src/lib.rs
@@ -130,6 +130,7 @@
 
 pub mod backend;
 pub mod buffer;
+pub mod compat;
 pub mod layout;
 pub mod symbols;
 pub mod terminal;

--- a/helix-tui/src/widgets/block.rs
+++ b/helix-tui/src/widgets/block.rs
@@ -102,6 +102,23 @@ impl<'a> Block<'a> {
         self
     }
 
+    // Public accessor methods for compatibility layer
+    pub fn get_borders(&self) -> Borders {
+        self.borders
+    }
+
+    pub fn get_border_type(&self) -> BorderType {
+        self.border_type
+    }
+
+    pub fn get_style(&self) -> Style {
+        self.style
+    }
+
+    pub fn get_title(&self) -> Option<&Spans<'a>> {
+        self.title.as_ref()
+    }
+
     /// Compute the inner area of a block based on its border visibility rules.
     pub fn inner(&self, area: Rect) -> Rect {
         let mut inner = area;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -494,6 +494,68 @@ impl Widget for Table<'_> {
     }
 }
 
+#[cfg(feature = "ratatui-migration")]
+impl<'a> Cell<'a> {
+    /// Convert this helix Cell to a ratatui Cell (accessing private fields)
+    pub fn to_ratatui_cell(self) -> ratatui::widgets::Cell<'a> {
+        use crate::compat::ratatui_compat::{convert_text, convert_style};
+        let ratatui_text = convert_text(self.content);
+        let ratatui_style = convert_style(self.style);
+        ratatui::widgets::Cell::from(ratatui_text).style(ratatui_style)
+    }
+}
+
+#[cfg(feature = "ratatui-migration")]
+impl<'a> Row<'a> {
+    /// Convert this helix Row to a ratatui Row (accessing private fields)
+    pub fn to_ratatui_row(self) -> ratatui::widgets::Row<'a> {
+        use crate::compat::ratatui_compat::convert_style;
+        let ratatui_cells: Vec<ratatui::widgets::Cell> = self.cells
+            .into_iter()
+            .map(|cell| cell.to_ratatui_cell())
+            .collect();
+        let ratatui_style = convert_style(self.style);
+        ratatui::widgets::Row::new(ratatui_cells)
+            .style(ratatui_style)
+            .height(self.height)
+            .bottom_margin(self.bottom_margin)
+    }
+}
+
+#[cfg(feature = "ratatui-migration")]
+impl<'a> Table<'a> {
+    /// Convert this helix Table to a ratatui Table (accessing private fields)
+    pub fn to_ratatui_table(self) -> ratatui::widgets::Table<'a> {
+        use crate::compat::ratatui_compat::{convert_style, convert_constraints, convert_block};
+        
+        let ratatui_rows: Vec<ratatui::widgets::Row> = self.rows
+            .into_iter()
+            .map(|row| row.to_ratatui_row())
+            .collect();
+        
+        let ratatui_constraints = convert_constraints(self.widths);
+        
+        let mut ratatui_table = ratatui::widgets::Table::new(ratatui_rows, ratatui_constraints)
+            .style(convert_style(self.style))
+            .highlight_style(convert_style(self.highlight_style))
+            .column_spacing(self.column_spacing);
+            
+        if let Some(symbol) = self.highlight_symbol {
+            ratatui_table = ratatui_table.highlight_symbol(symbol);
+        }
+        
+        if let Some(block) = self.block {
+            ratatui_table = ratatui_table.block(convert_block(block));
+        }
+        
+        if let Some(header) = self.header {
+            ratatui_table = ratatui_table.header(header.to_ratatui_row());
+        }
+        
+        ratatui_table
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -31,7 +31,7 @@ use helix_view::graphics::{Rect, Style};
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Cell<'a> {
     pub content: Text<'a>,
-    style: Style,
+    pub(crate) style: Style,
 }
 
 impl Cell<'_> {
@@ -76,9 +76,9 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Row<'a> {
     pub cells: Vec<Cell<'a>>,
-    height: u16,
-    style: Style,
-    bottom_margin: u16,
+    pub(crate) height: u16,
+    pub(crate) style: Style,
+    pub(crate) bottom_margin: u16,
 }
 
 impl<'a> Row<'a> {
@@ -187,21 +187,21 @@ impl<'a, T: Into<Cell<'a>>> From<T> for Row<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Table<'a> {
     /// A block to wrap the widget in
-    block: Option<Block<'a>>,
+    pub(crate) block: Option<Block<'a>>,
     /// Base style for the widget
-    style: Style,
+    pub(crate) style: Style,
     /// Width constraints for each column
-    widths: &'a [Constraint],
+    pub(crate) widths: &'a [Constraint],
     /// Space between each column
-    column_spacing: u16,
+    pub(crate) column_spacing: u16,
     /// Style used to render the selected row
-    highlight_style: Style,
+    pub(crate) highlight_style: Style,
     /// Symbol in front of the selected rom
-    highlight_symbol: Option<&'a str>,
+    pub(crate) highlight_symbol: Option<&'a str>,
     /// Optional header
-    header: Option<Row<'a>>,
+    pub(crate) header: Option<Row<'a>>,
     /// Data to display in each row
-    rows: Vec<Row<'a>>,
+    pub(crate) rows: Vec<Row<'a>>,
 }
 
 impl<'a> Table<'a> {

--- a/helix-tui/tests/backend_migration.rs
+++ b/helix-tui/tests/backend_migration.rs
@@ -1,0 +1,487 @@
+use helix_tui::{
+    backend::{Backend, TestBackend},
+    buffer::Cell,
+    terminal::{Config, Terminal},
+};
+use helix_view::graphics::{Color, CursorKind, Modifier, Rect, Style, UnderlineStyle};
+
+#[cfg(feature = "ratatui-migration")]
+use helix_tui::backend::RatatuiBackendAdapter;
+
+/// Test basic backend operations work consistently across implementations
+#[test]
+fn test_backend_trait_consistency() {
+    let mut test_backend = TestBackend::new(80, 24);
+    let config1 = Config { enable_mouse_capture: false };
+    let config2 = Config { enable_mouse_capture: false };
+    let config3 = Config { enable_mouse_capture: false };
+    
+    // Test all backend operations
+    assert!(test_backend.claim(config1).is_ok());
+    assert!(test_backend.reconfigure(config2).is_ok());
+    assert!(test_backend.hide_cursor().is_ok());
+    assert!(test_backend.show_cursor(CursorKind::Block).is_ok());
+    assert!(test_backend.set_cursor(10, 5).is_ok());
+    assert!(test_backend.get_cursor().is_ok());
+    assert!(test_backend.clear().is_ok());
+    assert!(test_backend.flush().is_ok());
+    assert!(test_backend.restore(config3).is_ok());
+    
+    // Test size
+    let size = test_backend.size().unwrap();
+    assert_eq!(size.width, 80);
+    assert_eq!(size.height, 24);
+}
+
+/// Test backend with Terminal integration
+#[test]
+fn test_backend_terminal_integration() {
+    let backend = TestBackend::new(60, 20);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let config1 = Config { enable_mouse_capture: false };
+    let config2 = Config { enable_mouse_capture: false };
+    
+    // Test terminal operations
+    assert!(terminal.claim(config1).is_ok());
+    assert!(terminal.hide_cursor().is_ok());
+    assert!(terminal.show_cursor(CursorKind::Bar).is_ok());
+    assert!(terminal.clear().is_ok());
+    
+    // Test buffer access
+    let buffer = terminal.current_buffer_mut();
+    buffer[(0, 0)] = Cell {
+        symbol: "A".to_string(),
+        fg: Color::Red,
+        bg: Color::Blue,
+        modifier: Modifier::BOLD,
+        underline_color: Color::Green,
+        underline_style: UnderlineStyle::Line,
+    };
+    
+    // Test drawing
+    assert!(terminal.draw(Some((5, 5)), CursorKind::Block).is_ok());
+    assert!(terminal.restore(config2).is_ok());
+}
+
+/// Test backend cell drawing operations
+#[test]
+fn test_backend_cell_drawing() {
+    let mut backend = TestBackend::new(40, 15);
+    
+    // Create test cells with various styles
+    let test_cells = vec![
+        (0, 0, Cell {
+            symbol: "H".to_string(),
+            fg: Color::Red,
+            bg: Color::Reset,
+            modifier: Modifier::BOLD,
+            underline_color: Color::Reset,
+            underline_style: UnderlineStyle::Reset,
+        }),
+        (1, 0, Cell {
+            symbol: "i".to_string(),
+            fg: Color::Green,
+            bg: Color::Yellow,
+            modifier: Modifier::ITALIC,
+            underline_color: Color::Reset,
+            underline_style: UnderlineStyle::Reset,
+        }),
+        (5, 2, Cell {
+            symbol: "!".to_string(),
+            fg: Color::Blue,
+            bg: Color::Reset,
+            modifier: Modifier::CROSSED_OUT,
+            underline_color: Color::Cyan,
+            underline_style: UnderlineStyle::Curl,
+        }),
+    ];
+    
+    // Draw cells to backend
+    let cell_iter = test_cells.iter().map(|(x, y, cell)| (*x, *y, cell));
+    assert!(backend.draw(cell_iter).is_ok());
+    
+    // Verify cells were drawn
+    let buffer = backend.buffer();
+    assert_eq!(buffer[(0, 0)].symbol, "H");
+    assert_eq!(buffer[(1, 0)].symbol, "i");
+    assert_eq!(buffer[(5, 2)].symbol, "!");
+}
+
+/// Test backend edge cases and error handling
+#[test]
+fn test_backend_edge_cases() {
+    let mut backend = TestBackend::new(10, 5);
+    
+    // Test out-of-bounds operations
+    assert!(backend.set_cursor(15, 10).is_ok()); // Should not panic
+    
+    // Test zero-size operations
+    let mut zero_backend = TestBackend::new(0, 0);
+    assert!(zero_backend.clear().is_ok());
+    assert!(zero_backend.flush().is_ok());
+    
+    // Test drawing to empty buffer
+    let empty_cells: Vec<(u16, u16, &Cell)> = vec![];
+    assert!(backend.draw(empty_cells.into_iter()).is_ok());
+}
+
+/// Test backend resizing behavior
+#[test]
+fn test_backend_resize_behavior() {
+    let mut backend = TestBackend::new(20, 10);
+    
+    // Set some initial content
+    let cell = Cell {
+        symbol: "X".to_string(),
+        fg: Color::White,
+        bg: Color::Black,
+        modifier: Modifier::empty(),
+        underline_color: Color::Reset,
+        underline_style: UnderlineStyle::Reset,
+    };
+    
+    let cells = vec![(5, 5, &cell)];
+    assert!(backend.draw(cells.into_iter()).is_ok());
+    
+    // Resize backend
+    backend.resize(40, 20);
+    
+    // Verify new size
+    let size = backend.size().unwrap();
+    assert_eq!(size.width, 40);
+    assert_eq!(size.height, 20);
+    
+    // Previous content should be cleared after resize
+    let buffer = backend.buffer();
+    assert_eq!(buffer.area, Rect::new(0, 0, 40, 20));
+}
+
+#[cfg(feature = "ratatui-migration")]
+mod ratatui_tests {
+    use super::*;
+    use ratatui::backend::TestBackend as RatatuiTestBackend;
+    
+    /// Test ratatui backend adapter basic operations
+    #[test]
+    fn test_ratatui_backend_adapter() {
+        let ratatui_backend = RatatuiTestBackend::new(80, 24);
+        let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+        let config1 = Config { enable_mouse_capture: false };
+        let config2 = Config { enable_mouse_capture: false };
+        let config3 = Config { enable_mouse_capture: false };
+        
+        // Test all backend trait methods
+        assert!(adapter.claim(config1).is_ok());
+        assert!(adapter.reconfigure(config2).is_ok());
+        assert!(adapter.hide_cursor().is_ok());
+        assert!(adapter.show_cursor(CursorKind::Underline).is_ok());
+        assert!(adapter.set_cursor(20, 10).is_ok());
+        assert!(adapter.clear().is_ok());
+        assert!(adapter.flush().is_ok());
+        assert!(adapter.restore(config3).is_ok());
+        
+        // Test size
+        let size = adapter.size().unwrap();
+        assert_eq!(size.width, 80);
+        assert_eq!(size.height, 24);
+    }
+    
+    /// Test ratatui adapter with Terminal
+    #[test]
+    fn test_ratatui_adapter_terminal_integration() {
+        let ratatui_backend = RatatuiTestBackend::new(50, 18);
+        let adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+        let mut terminal = Terminal::new(adapter).unwrap();
+        let config1 = Config { enable_mouse_capture: false };
+        let config2 = Config { enable_mouse_capture: false };
+        
+        // Test terminal operations with ratatui adapter
+        assert!(terminal.claim(config1).is_ok());
+        
+        // Test buffer operations
+        let buffer = terminal.current_buffer_mut();
+        buffer[(10, 5)] = Cell {
+            symbol: "R".to_string(),
+            fg: Color::Magenta,
+            bg: Color::Cyan,
+            modifier: Modifier::BOLD | Modifier::ITALIC,
+            underline_color: Color::Yellow,
+            underline_style: UnderlineStyle::Dotted,
+        };
+        
+        // Test drawing
+        assert!(terminal.draw(Some((10, 5)), CursorKind::Bar).is_ok());
+        assert!(terminal.restore(config2).is_ok());
+    }
+    
+    /// Test cell conversion between helix and ratatui formats
+    #[test]
+    fn test_cell_conversion_compatibility() {
+        use helix_tui::compat::ratatui_compat::{convert_cell, convert_cell_back};
+        
+        let helix_cell = Cell {
+            symbol: "★".to_string(),
+            fg: Color::Rgb(255, 128, 0),
+            bg: Color::Indexed(42),
+            modifier: Modifier::BOLD | Modifier::REVERSED,
+            underline_color: Color::Green,
+            underline_style: UnderlineStyle::Curl,
+        };
+        
+        // Convert to ratatui and back
+        let ratatui_cell = convert_cell(&helix_cell);
+        let converted_back = convert_cell_back(&ratatui_cell);
+        
+        // Verify core properties are preserved
+        assert_eq!(helix_cell.symbol, converted_back.symbol);
+        assert_eq!(helix_cell.fg, converted_back.fg);
+        assert_eq!(helix_cell.bg, converted_back.bg);
+        assert_eq!(helix_cell.modifier, converted_back.modifier);
+        // Note: underline properties may not round-trip perfectly due to differences
+    }
+    
+    /// Test adapter drawing with styled content
+    #[test]
+    fn test_ratatui_adapter_styled_drawing() {
+        let ratatui_backend = RatatuiTestBackend::new(30, 12);
+        let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+        
+        // Create styled cells
+        let styled_cells = vec![
+            (0, 0, Cell {
+                symbol: "A".to_string(),
+                fg: Color::Red,
+                bg: Color::Reset,
+                modifier: Modifier::BOLD,
+                underline_color: Color::Reset,
+                underline_style: UnderlineStyle::Reset,
+            }),
+            (1, 0, Cell {
+                symbol: "B".to_string(),
+                fg: Color::Green,
+                bg: Color::Blue,
+                modifier: Modifier::ITALIC,
+                underline_color: Color::Yellow,
+                underline_style: UnderlineStyle::Line,
+            }),
+            (2, 0, Cell {
+                symbol: "C".to_string(),
+                fg: Color::Rgb(128, 64, 192),
+                bg: Color::Indexed(8),
+                modifier: Modifier::DIM | Modifier::CROSSED_OUT,
+                underline_color: Color::Magenta,
+                underline_style: UnderlineStyle::Dashed,
+            }),
+        ];
+        
+        let cell_iter = styled_cells.iter().map(|(x, y, cell)| (*x, *y, cell));
+        assert!(adapter.draw(cell_iter).is_ok());
+        assert!(adapter.flush().is_ok());
+    }
+    
+    /// Test adapter cursor operations
+    #[test]
+    fn test_ratatui_adapter_cursor_operations() {
+        let ratatui_backend = RatatuiTestBackend::new(25, 10);
+        let mut adapter = RatatuiBackendAdapter::new(ratatui_backend).unwrap();
+        
+        // Test different cursor kinds
+        let cursor_kinds = vec![
+            CursorKind::Block,
+            CursorKind::Bar,
+            CursorKind::Underline,
+            CursorKind::Hidden,
+        ];
+        
+        for kind in cursor_kinds {
+            assert!(adapter.show_cursor(kind).is_ok());
+            assert!(adapter.set_cursor(12, 6).is_ok());
+            let (x, y) = adapter.get_cursor().unwrap();
+            assert_eq!(x, 12);
+            assert_eq!(y, 6);
+        }
+        
+        assert!(adapter.hide_cursor().is_ok());
+    }
+}
+
+/// Test backend performance with large content
+#[test]
+fn test_backend_performance_baseline() {
+    let mut backend = TestBackend::new(200, 100);
+    
+    // Create large amount of content
+    let mut cells = Vec::new();
+    for y in 0u16..100 {
+        for x in 0u16..200 {
+            cells.push((x, y, Cell {
+                symbol: (((x + y) % 26 + 65) as u8 as char).to_string(),
+                fg: Color::Indexed(((x + y) % 256) as u8),
+                bg: Color::Reset,
+                modifier: if (x + y) % 3 == 0 { Modifier::BOLD } else { Modifier::empty() },
+                underline_color: Color::Reset,
+                underline_style: UnderlineStyle::Reset,
+            }));
+        }
+    }
+    
+    let cell_refs: Vec<(u16, u16, &Cell)> = cells.iter().map(|(x, y, cell)| (*x, *y, cell)).collect();
+    
+    // This should complete without panicking or taking excessive time
+    assert!(backend.draw(cell_refs.into_iter()).is_ok());
+    assert!(backend.flush().is_ok());
+    
+    // Verify some content was drawn
+    let buffer = backend.buffer();
+    assert!(!buffer.content().is_empty());
+}
+
+/// Test concurrent backend operations don't interfere
+#[test]
+fn test_backend_isolation() {
+    let mut backend1 = TestBackend::new(20, 10);
+    let mut backend2 = TestBackend::new(30, 15);
+    
+    // Set different content on each backend
+    let cell1 = Cell {
+        symbol: "1".to_string(),
+        fg: Color::Red,
+        bg: Color::Reset,
+        modifier: Modifier::BOLD,
+        underline_color: Color::Reset,
+        underline_style: UnderlineStyle::Reset,
+    };
+    
+    let cell2 = Cell {
+        symbol: "2".to_string(),
+        fg: Color::Blue,
+        bg: Color::Yellow,
+        modifier: Modifier::ITALIC,
+        underline_color: Color::Reset,
+        underline_style: UnderlineStyle::Reset,
+    };
+    
+    assert!(backend1.draw(vec![(5, 5, &cell1)].into_iter()).is_ok());
+    assert!(backend2.draw(vec![(10, 8, &cell2)].into_iter()).is_ok());
+    
+    // Verify isolation - each backend should have its own content
+    assert_eq!(backend1.buffer()[(5, 5)].symbol, "1");
+    assert_eq!(backend2.buffer()[(10, 8)].symbol, "2");
+    
+    // Backend1 should not have backend2's content
+    assert_ne!(backend1.buffer()[(10, 8)].symbol, "2");
+}
+
+/// Test backend compatibility with various cell styles
+#[test]
+fn test_backend_style_compatibility() {
+    let mut backend = TestBackend::new(50, 20);
+    
+    let style_test_cases = vec![
+        ("Basic colors", Style::default().fg(Color::Red).bg(Color::Blue)),
+        ("RGB colors", Style::default().fg(Color::Rgb(128, 64, 255)).bg(Color::Rgb(32, 128, 16))),
+        ("Indexed colors", Style::default().fg(Color::Indexed(196)).bg(Color::Indexed(46))),
+        ("Bold modifier", Style::default().add_modifier(Modifier::BOLD)),
+        ("Multiple modifiers", Style::default().add_modifier(Modifier::BOLD | Modifier::ITALIC | Modifier::CROSSED_OUT)),
+        ("Underline style", Style::default().underline_color(Color::Cyan).underline_style(UnderlineStyle::Curl)),
+        ("Complex style", Style::default()
+            .fg(Color::LightMagenta)
+            .bg(Color::Gray)
+            .add_modifier(Modifier::DIM | Modifier::REVERSED)
+            .underline_color(Color::LightGreen)
+            .underline_style(UnderlineStyle::DoubleLine)),
+    ];
+    
+    for (i, (name, style)) in style_test_cases.iter().enumerate() {
+        let cell = Cell {
+            symbol: format!("{}", i),
+            fg: style.fg.unwrap_or(Color::Reset),
+            bg: style.bg.unwrap_or(Color::Reset),
+            modifier: style.add_modifier,
+            underline_color: style.underline_color.unwrap_or(Color::Reset),
+            underline_style: style.underline_style.unwrap_or(UnderlineStyle::Reset),
+        };
+        
+        assert!(backend.draw(vec![(i as u16, 0, &cell)].into_iter()).is_ok(), 
+                "Failed to draw cell for style test: {}", name);
+    }
+    
+    assert!(backend.flush().is_ok());
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Test compatibility between helix-tui and ratatui backends
+#[test]
+fn test_cross_backend_compatibility() {
+    use ratatui::backend::TestBackend as RatatuiTestBackend;
+    
+    // Create both types of backends
+    let helix_backend = TestBackend::new(40, 20);
+    let ratatui_backend = RatatuiBackendAdapter::new(
+        RatatuiTestBackend::new(40, 20)
+    ).unwrap();
+    
+    // Create terminals with both backends
+    let mut helix_terminal = Terminal::new(helix_backend).unwrap();
+    let mut ratatui_terminal = Terminal::new(ratatui_backend).unwrap();
+    
+    let config1 = Config { enable_mouse_capture: false };
+    let config2 = Config { enable_mouse_capture: false };
+    let config3 = Config { enable_mouse_capture: false };
+    let config4 = Config { enable_mouse_capture: false };
+    
+    // Test that both terminals support the same operations
+    assert!(helix_terminal.claim(config1).is_ok());
+    assert!(ratatui_terminal.claim(config2).is_ok());
+    
+    // Both should support the same size
+    assert_eq!(helix_terminal.size().unwrap(), ratatui_terminal.size().unwrap());
+    
+    // Both should support drawing operations
+    assert!(helix_terminal.draw(Some((10, 10)), CursorKind::Block).is_ok());
+    assert!(ratatui_terminal.draw(Some((10, 10)), CursorKind::Block).is_ok());
+    
+    assert!(helix_terminal.restore(config3).is_ok());
+    assert!(ratatui_terminal.restore(config4).is_ok());
+}
+
+#[cfg(feature = "ratatui-migration")]
+/// Test that conversion functions work correctly
+#[test]
+fn test_conversion_functions() {
+    use helix_tui::compat::ratatui_compat::{
+        convert_color, convert_color_back, 
+        convert_rect, convert_rect_back,
+        convert_style,
+    };
+    
+    // Test color round-trip
+    let colors = vec![
+        Color::Reset, Color::Red, Color::Green, Color::Blue,
+        Color::Rgb(255, 128, 64), Color::Indexed(42),
+    ];
+    
+    for color in colors {
+        let ratatui_color = convert_color(color);
+        let back_color = convert_color_back(ratatui_color);
+        assert_eq!(color, back_color, "Color conversion round-trip failed for {:?}", color);
+    }
+    
+    // Test rect round-trip
+    let rect = Rect::new(15, 25, 100, 50);
+    let ratatui_rect = convert_rect(rect);
+    let back_rect = convert_rect_back(ratatui_rect);
+    assert_eq!(rect, back_rect);
+    
+    // Test style conversion
+    let style = Style::default()
+        .fg(Color::Yellow)
+        .bg(Color::Magenta)
+        .add_modifier(Modifier::BOLD | Modifier::ITALIC);
+    
+    let ratatui_style = convert_style(style);
+    assert_eq!(ratatui_style.fg, Some(ratatui::style::Color::Yellow));
+    assert_eq!(ratatui_style.bg, Some(ratatui::style::Color::Magenta));
+    assert!(ratatui_style.add_modifier.contains(ratatui::style::Modifier::BOLD));
+    assert!(ratatui_style.add_modifier.contains(ratatui::style::Modifier::ITALIC));
+}

--- a/helix-tui/tests/buffer_regression.rs
+++ b/helix-tui/tests/buffer_regression.rs
@@ -1,0 +1,158 @@
+use helix_tui::buffer::Buffer;
+use helix_view::graphics::{Color, Style, Rect, Modifier, UnderlineStyle};
+
+#[test]
+fn test_buffer_basic_operations() {
+    // Test basic buffer cell manipulation
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+    
+    // Test setting cells with different styles
+    buffer.get_mut(0, 0).unwrap().set_char('X').set_fg(Color::Red);
+    buffer.get_mut(1, 0).unwrap().set_char('Y').set_bg(Color::Blue);
+    
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, "X");
+    assert_eq!(buffer.get(0, 0).unwrap().fg, Color::Red);
+    assert_eq!(buffer.get(1, 0).unwrap().bg, Color::Blue);
+}
+
+#[test]
+fn test_buffer_cell_style_operations() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 5));
+    
+    // Test setting styles with various combinations
+    let style = Style::default()
+        .fg(Color::Red)
+        .bg(Color::Blue)
+        .add_modifier(Modifier::BOLD)
+        .underline_style(UnderlineStyle::Curl);
+        
+    buffer.get_mut(2, 2).unwrap().set_style(style);
+    
+    let cell = buffer.get(2, 2).unwrap();
+    assert_eq!(cell.fg, Color::Red);
+    assert_eq!(cell.bg, Color::Blue);
+    assert!(cell.modifier.contains(Modifier::BOLD));
+    assert_eq!(cell.underline_style, UnderlineStyle::Curl);
+}
+
+#[test] 
+fn test_buffer_resize_and_bounds() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+    buffer.get_mut(5, 5).unwrap().set_char('X');
+    
+    // Test bounds checking
+    assert!(buffer.get(0, 0).is_some());
+    assert!(buffer.get(9, 9).is_some());
+    assert!(buffer.get(10, 10).is_none()); // Out of bounds
+    assert!(buffer.get(5, 10).is_none()); // Out of bounds
+    
+    // Test that buffer maintains content correctly
+    assert_eq!(buffer.get(5, 5).unwrap().symbol, "X");
+}
+
+#[test]
+fn test_buffer_with_lines() {
+    // Test buffer creation from lines (used in visual tests)
+    let lines = vec![
+        "Hello, world!",
+        "Second line",
+        "Third line with unicode: 🦀",
+    ];
+    
+    let buffer = Buffer::with_lines(lines.clone());
+    
+    // Verify dimensions
+    assert_eq!(buffer.area.height, 3);
+    // Unicode character 🦀 takes 2 display columns, so "Third line with unicode: 🦀" is 27 chars wide
+    assert_eq!(buffer.area.width, 27);
+    
+    // Verify content is preserved
+    let reconstructed: Vec<String> = (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer.get(x, y).map(|c| c.symbol.as_str()).unwrap_or(" "))
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect();
+    
+    assert_eq!(reconstructed[0], "Hello, world!");
+    assert_eq!(reconstructed[1], "Second line");
+    assert!(reconstructed[2].contains("🦀"));
+}
+
+#[test]
+fn test_buffer_set_string() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 5));
+    
+    // Test setting string with style
+    let style = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
+    buffer.set_string(2, 1, "Hello", style);
+    
+    // Verify each character has the correct style
+    for i in 0..5 {
+        let cell = buffer.get(2 + i, 1).unwrap();
+        assert_eq!(cell.fg, Color::Green);
+        assert!(cell.modifier.contains(Modifier::BOLD));
+    }
+    
+    // Verify content
+    assert_eq!(buffer.get(2, 1).unwrap().symbol, "H");
+    assert_eq!(buffer.get(6, 1).unwrap().symbol, "o");
+}
+
+#[test]
+fn test_buffer_edge_cases() {
+    // Test zero-size buffer
+    let buffer = Buffer::empty(Rect::new(0, 0, 0, 0));
+    assert_eq!(buffer.content.len(), 0);
+    assert!(buffer.get(0, 0).is_none());
+    
+    // Test 1x1 buffer
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 1, 1));
+    buffer.get_mut(0, 0).unwrap().set_char('X');
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, "X");
+    
+    // Test large buffer creation (performance check)
+    let buffer = Buffer::empty(Rect::new(0, 0, 100, 100));
+    assert_eq!(buffer.content.len(), 10_000);
+}
+
+#[test]
+fn test_buffer_cell_reset() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 5, 5));
+    
+    // Set up a cell with complex styling
+    let cell = buffer.get_mut(2, 2).unwrap();
+    cell.set_char('X')
+        .set_fg(Color::Red)
+        .set_bg(Color::Blue)
+        .set_style(Style::default().add_modifier(Modifier::BOLD));
+    
+    // Reset the cell
+    cell.reset();
+    
+    // Verify reset state
+    assert_eq!(cell.symbol, " ");
+    assert_eq!(cell.fg, Color::Reset);
+    assert_eq!(cell.bg, Color::Reset);
+    assert_eq!(cell.modifier, Modifier::empty());
+}
+
+#[test]
+fn test_buffer_unicode_handling() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 5));
+    
+    // Test various unicode characters
+    let unicode_chars = vec!['🦀', '🚀', '💻', '📝', '🎯'];
+    
+    for (i, ch) in unicode_chars.iter().enumerate() {
+        buffer.get_mut(i as u16, 0).unwrap().set_char(*ch);
+        assert_eq!(buffer.get(i as u16, 0).unwrap().symbol, ch.to_string());
+    }
+    
+    // Test emoji with skin tone modifiers
+    buffer.set_string(0, 1, "👋🏽", Style::default());
+    // Should handle complex unicode sequences properly
+}

--- a/helix-tui/tests/color_style_system.rs
+++ b/helix-tui/tests/color_style_system.rs
@@ -1,0 +1,193 @@
+use helix_view::graphics::{Color, Modifier, Style, Rect};
+use helix_tui::buffer::{Buffer, Cell};
+
+#[test]
+fn test_color_combinations() {
+    // Test basic color combinations work without panic
+    let colors = vec![
+        Color::Black,
+        Color::Red, 
+        Color::Green,
+        Color::Yellow,
+        Color::Blue,
+        Color::Magenta,
+        Color::Cyan,
+        Color::Gray,
+        Color::LightGray,
+        Color::LightRed,
+        Color::LightGreen,
+        Color::LightYellow,
+        Color::LightBlue,
+        Color::LightMagenta,
+        Color::LightCyan,
+        Color::White,
+        Color::Rgb(128, 128, 128),
+        Color::Indexed(42),
+    ];
+
+    for fg in &colors {
+        for bg in &colors {
+            let style = Style::default().fg(*fg).bg(*bg);
+            // Test style creation doesn't panic
+            assert_eq!(style.fg, Some(*fg));
+            assert_eq!(style.bg, Some(*bg));
+        }
+    }
+}
+
+#[test]
+fn test_style_modifiers() {
+    // Test all modifier combinations
+    let modifiers = vec![
+        Modifier::BOLD,
+        Modifier::DIM,
+        Modifier::ITALIC,
+        Modifier::SLOW_BLINK,
+        Modifier::RAPID_BLINK,
+        Modifier::REVERSED,
+        Modifier::HIDDEN,
+        Modifier::CROSSED_OUT,
+    ];
+
+    for modifier in &modifiers {
+        let style = Style::default().add_modifier(*modifier);
+        assert!(style.add_modifier.contains(*modifier));
+        
+        let style = Style::default().remove_modifier(*modifier);
+        assert!(style.sub_modifier.contains(*modifier));
+    }
+    
+    // Test multiple modifiers
+    let style = Style::default()
+        .add_modifier(Modifier::BOLD)
+        .add_modifier(Modifier::ITALIC)
+        .add_modifier(Modifier::CROSSED_OUT);
+    
+    assert!(style.add_modifier.contains(Modifier::BOLD));
+    assert!(style.add_modifier.contains(Modifier::ITALIC));
+    assert!(style.add_modifier.contains(Modifier::CROSSED_OUT));
+}
+
+#[test]
+fn test_style_patches() {
+    let base_style = Style::default()
+        .fg(Color::Red)
+        .bg(Color::Blue)
+        .add_modifier(Modifier::BOLD);
+    
+    let patch_style = Style::default()
+        .fg(Color::Green)
+        .add_modifier(Modifier::ITALIC);
+    
+    let patched = base_style.patch(patch_style);
+    
+    // Foreground should be overridden
+    assert_eq!(patched.fg, Some(Color::Green));
+    // Background should be preserved
+    assert_eq!(patched.bg, Some(Color::Blue));
+    // Both modifiers should be present
+    assert!(patched.add_modifier.contains(Modifier::BOLD));
+    assert!(patched.add_modifier.contains(Modifier::ITALIC));
+}
+
+#[test]
+fn test_buffer_cell_styling() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 10));
+    
+    // Test setting styles on buffer cells
+    let style1 = Style::default().fg(Color::Red).bg(Color::Blue);
+    let style2 = Style::default().fg(Color::Green).add_modifier(Modifier::BOLD);
+    
+    if let Some(cell1) = buffer.get_mut(0, 0) {
+        cell1.set_style(style1);
+        let cell_style = cell1.style();
+        assert_eq!(cell_style.fg, Some(Color::Red));
+        assert_eq!(cell_style.bg, Some(Color::Blue));
+    }
+    
+    if let Some(cell2) = buffer.get_mut(1, 1) {
+        cell2.set_style(style2);
+        let cell_style = cell2.style();
+        assert_eq!(cell_style.fg, Some(Color::Green));
+        assert!(cell_style.add_modifier.contains(Modifier::BOLD));
+    }
+    
+    // Test that different cells maintain their styles
+    if let Some(cell) = buffer.get(0, 0) {
+        let cell_style = cell.style();
+        assert_eq!(cell_style.fg, Some(Color::Red));
+        assert_eq!(cell_style.bg, Some(Color::Blue));
+    }
+    if let Some(cell) = buffer.get(1, 1) {
+        let cell_style = cell.style();
+        assert_eq!(cell_style.fg, Some(Color::Green));
+        assert!(cell_style.add_modifier.contains(Modifier::BOLD));
+    }
+}
+
+#[test]
+fn test_cell_symbol_and_style() {
+    let mut cell = Cell::default();
+    
+    // Test symbol setting
+    cell.set_symbol("A");
+    assert_eq!(cell.symbol, "A");
+    
+    // Test style setting  
+    let style = Style::default().fg(Color::Yellow);
+    cell.set_style(style);
+    let cell_style = cell.style();
+    assert_eq!(cell_style.fg, Some(Color::Yellow));
+    
+    // Test chaining
+    cell.set_symbol("B").set_style(Style::default().bg(Color::Magenta));
+    assert_eq!(cell.symbol, "B");
+    assert_eq!(cell.style().bg, Some(Color::Magenta));
+}
+
+#[test]
+fn test_color_parsing_rgb() {
+    // Test RGB color creation
+    let color1 = Color::Rgb(255, 0, 0); // Red
+    let color2 = Color::Rgb(0, 255, 0); // Green  
+    let color3 = Color::Rgb(0, 0, 255); // Blue
+    
+    // Test indexed colors
+    for i in 0..=255 {
+        let _color = Color::Indexed(i);
+        // Just test creation doesn't panic
+    }
+    
+    // Test that colors are equality comparable
+    assert_eq!(Color::Red, Color::Red);
+    assert_ne!(Color::Red, Color::Blue);
+    assert_eq!(Color::Rgb(255, 0, 0), Color::Rgb(255, 0, 0));
+    assert_ne!(Color::Rgb(255, 0, 0), Color::Rgb(0, 255, 0));
+}
+
+#[test]
+fn test_style_reset() {
+    let style = Style::default()
+        .fg(Color::Red)
+        .bg(Color::Blue)
+        .add_modifier(Modifier::BOLD)
+        .add_modifier(Modifier::ITALIC);
+    
+    // Test resetting individual components
+    let no_fg = Style::default()
+        .bg(Color::Blue)
+        .add_modifier(Modifier::BOLD)
+        .add_modifier(Modifier::ITALIC);
+        
+    let reset_style = Style {
+        fg: None,
+        bg: style.bg,
+        underline_color: style.underline_color,
+        underline_style: style.underline_style,
+        add_modifier: style.add_modifier,
+        sub_modifier: style.sub_modifier,
+    };
+    
+    assert_eq!(reset_style.fg, None);
+    assert_eq!(reset_style.bg, Some(Color::Blue));
+}

--- a/helix-tui/tests/performance_baseline.rs
+++ b/helix-tui/tests/performance_baseline.rs
@@ -1,0 +1,181 @@
+use helix_tui::buffer::{Buffer, Cell};
+use helix_view::graphics::{Color, Style, Rect};
+use std::time::Instant;
+
+#[test]
+fn test_buffer_creation_performance() {
+    // Test buffer creation time for various sizes
+    let test_cases = vec![
+        (80, 24),      // Standard terminal
+        (120, 40),     // Larger terminal  
+        (200, 50),     // Very wide terminal
+        (300, 100),    // Large terminal
+    ];
+
+    for (width, height) in test_cases {
+        let start = Instant::now();
+        let _buffer = Buffer::empty(Rect::new(0, 0, width, height));
+        let duration = start.elapsed();
+        
+        // Performance baseline: buffer creation should be under 10ms
+        assert!(duration.as_millis() < 10, 
+                "Buffer creation for {}x{} took {}ms, expected < 10ms", 
+                width, height, duration.as_millis());
+    }
+}
+
+#[test]
+fn test_buffer_resize_performance() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 80, 24));
+    
+    let resize_operations = vec![
+        (120, 40),
+        (200, 50), 
+        (80, 24),
+        (40, 12),
+        (300, 100),
+    ];
+
+    for (width, height) in resize_operations {
+        let start = Instant::now();
+        buffer.resize(Rect::new(0, 0, width, height));
+        let duration = start.elapsed();
+        
+        // Performance baseline: resize should be under 5ms
+        assert!(duration.as_millis() < 5,
+                "Buffer resize to {}x{} took {}ms, expected < 5ms",
+                width, height, duration.as_millis());
+    }
+}
+
+#[test]
+fn test_cell_manipulation_performance() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 200, 100));
+    let style = Style::default().fg(Color::Red).bg(Color::Blue);
+    
+    let start = Instant::now();
+    
+    // Fill buffer with styled content
+    for y in 0..100 {
+        for x in 0..200 {
+            if let Some(cell) = buffer.get_mut(x, y) {
+                cell.set_symbol("X").set_style(style);
+            }
+        }
+    }
+    
+    let duration = start.elapsed();
+    
+    // Performance baseline: filling 20k cells should be under 50ms
+    assert!(duration.as_millis() < 50,
+            "Filling 20,000 cells took {}ms, expected < 50ms",
+            duration.as_millis());
+}
+
+#[test]
+fn test_buffer_diff_performance() {
+    let area = Rect::new(0, 0, 100, 50);
+    let mut buffer1 = Buffer::empty(area);
+    let mut buffer2 = Buffer::empty(area);
+    
+    // Fill buffers with different content
+    for y in 0..50 {
+        for x in 0..100 {
+            if let Some(cell) = buffer1.get_mut(x, y) {
+                cell.set_symbol("A");
+            }
+            if let Some(cell) = buffer2.get_mut(x, y) {
+                cell.set_symbol("B");
+            }
+        }
+    }
+    
+    let start = Instant::now();
+    let _diff = buffer1.diff(&buffer2);
+    let duration = start.elapsed();
+    
+    // Performance baseline: diffing 5k cells should be under 20ms
+    assert!(duration.as_millis() < 20,
+            "Diffing 5,000 cells took {}ms, expected < 20ms", 
+            duration.as_millis());
+}
+
+#[test]
+fn test_string_rendering_performance() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 100, 50));
+    let style = Style::default().fg(Color::Green);
+    
+    let test_strings = vec![
+        "Short string",
+        "This is a much longer string that spans more characters",
+        "Unicode: こんにちは世界 🌍 Émojis: 🚀🎉",
+        "Mixed: ASCII + Unicode + Émoji 💻 Programming",
+    ];
+    
+    let start = Instant::now();
+    
+    for (i, test_str) in test_strings.iter().enumerate() {
+        let y = i as u16;
+        buffer.set_string(0, y, test_str, style);
+        buffer.set_string(0, y + 10, test_str, style);
+        buffer.set_string(0, y + 20, test_str, style);
+        buffer.set_string(0, y + 30, test_str, style);
+    }
+    
+    let duration = start.elapsed();
+    
+    // Performance baseline: rendering strings should be under 10ms
+    assert!(duration.as_millis() < 10,
+            "String rendering took {}ms, expected < 10ms",
+            duration.as_millis());
+}
+
+#[test]
+fn test_large_buffer_access_patterns() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 500, 200));
+    
+    let start = Instant::now();
+    
+    // Test random access pattern
+    for i in 0..1000 {
+        let x = (i * 7) % 500;
+        let y = (i * 11) % 200;
+        if let Some(cell) = buffer.get_mut(x, y) {
+            cell.set_symbol("*");
+        }
+    }
+    
+    let duration = start.elapsed();
+    
+    // Performance baseline: 1000 random accesses should be under 5ms
+    assert!(duration.as_millis() < 5,
+            "1000 random buffer accesses took {}ms, expected < 5ms",
+            duration.as_millis());
+}
+
+#[test]
+fn test_buffer_clone_performance() {
+    let area = Rect::new(0, 0, 150, 75);
+    let mut original = Buffer::empty(area);
+    let style = Style::default().fg(Color::Cyan);
+    
+    // Fill with some content
+    for y in 0..75 {
+        for x in 0..150 {
+            if (x + y) % 3 == 0 {
+                if let Some(cell) = original.get_mut(x, y) {
+                    cell.set_symbol("@").set_style(style);
+                }
+            }
+        }
+    }
+    
+    let start = Instant::now();
+    let _cloned = original.clone();
+    let duration = start.elapsed();
+    
+    // Performance baseline: cloning 11.25k cells should be under 20ms  
+    assert!(duration.as_millis() < 20,
+            "Cloning buffer with 11,250 cells took {}ms, expected < 20ms",
+            duration.as_millis());
+}

--- a/helix-tui/tests/terminal_compatibility.rs
+++ b/helix-tui/tests/terminal_compatibility.rs
@@ -1,0 +1,110 @@
+use helix_tui::backend::{Backend, TestBackend};
+use helix_tui::Terminal;
+use helix_view::graphics::{CursorKind, Rect};
+
+#[test]
+fn test_terminal_creation_and_size() {
+    // Test terminal creation with various sizes
+    let test_sizes = vec![
+        (1, 1),       // Minimal
+        (80, 24),     // Standard terminal
+        (120, 40),    // Larger terminal
+        (200, 50),    // Very wide
+    ];
+    
+    for (width, height) in test_sizes {
+        let backend = TestBackend::new(width, height);
+        let terminal = Terminal::new(backend).unwrap();
+        let size = terminal.backend().size().unwrap();
+        
+        assert_eq!(size.width, width);
+        assert_eq!(size.height, height);
+        assert_eq!(size, Rect::new(0, 0, width, height));
+    }
+}
+
+#[test]
+fn test_terminal_zero_size() {
+    // Test edge case: zero size terminal
+    let backend = TestBackend::new(0, 0);
+    let terminal = Terminal::new(backend).unwrap();
+    let size = terminal.backend().size().unwrap();
+    
+    assert_eq!(size.width, 0);
+    assert_eq!(size.height, 0);
+    assert_eq!(size.area(), 0);
+}
+
+#[test]
+fn test_backend_cursor_operations() {
+    let mut backend = TestBackend::new(80, 24);
+    
+    // Test cursor positioning
+    assert!(backend.set_cursor(10, 5).is_ok());
+    assert_eq!(backend.get_cursor().unwrap(), (10, 5));
+    
+    // Test cursor at edges
+    assert!(backend.set_cursor(0, 0).is_ok());
+    assert_eq!(backend.get_cursor().unwrap(), (0, 0));
+    
+    assert!(backend.set_cursor(79, 23).is_ok());
+    assert_eq!(backend.get_cursor().unwrap(), (79, 23));
+}
+
+#[test]
+fn test_backend_cursor_kinds() {
+    let mut backend = TestBackend::new(80, 24);
+    
+    // Test all cursor kinds work without panic
+    let cursor_kinds = vec![
+        CursorKind::Block,
+        CursorKind::Bar, 
+        CursorKind::Underline,
+        CursorKind::Hidden,
+    ];
+    
+    for cursor_kind in cursor_kinds {
+        assert!(backend.show_cursor(cursor_kind).is_ok());
+        assert!(backend.hide_cursor().is_ok());
+    }
+}
+
+#[test]
+fn test_backend_basic_operations() {
+    let mut backend = TestBackend::new(80, 24);
+    
+    // Test basic backend operations don't panic
+    assert!(backend.clear().is_ok());
+    assert!(backend.flush().is_ok());
+    
+    // Test initial cursor position
+    let (x, y) = backend.get_cursor().unwrap();
+    assert!(x < 80);
+    assert!(y < 24);
+}
+
+#[test]
+fn test_terminal_draw_basic() {
+    let backend = TestBackend::new(10, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    // Test basic draw operation doesn't panic
+    let result = terminal.draw(None, CursorKind::Block);
+    assert!(result.is_ok());
+    
+    // Test draw with cursor position
+    let result = terminal.draw(Some((5, 5)), CursorKind::Bar);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_terminal_multiple_draws() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    // Test multiple consecutive draws
+    for i in 0..5 {
+        let result = terminal.draw(None, CursorKind::Block);
+        assert!(result.is_ok(), "Draw iteration {} failed", i);
+    }
+}

--- a/helix-tui/tests/widget_migration.rs
+++ b/helix-tui/tests/widget_migration.rs
@@ -1,0 +1,234 @@
+use helix_tui::backend::TestBackend;
+use helix_tui::Terminal;
+use helix_tui::widgets::{Block, Borders, Widget, Paragraph, Table, Row, Cell};
+use helix_tui::text::{Spans, Span, Text};
+use helix_tui::layout::Constraint;
+use helix_view::graphics::{Color, Style, Modifier, Rect};
+
+/// Test that Block widget rendering produces consistent output
+#[test]
+fn test_block_widget_migration_compatibility() {
+    let backend = TestBackend::new(20, 10);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 20, 10);
+    
+    // Test various block configurations
+    let test_cases = vec![
+        ("Basic block", Block::default().borders(Borders::ALL)),
+        ("Block with title", Block::default().borders(Borders::ALL).title("Test Title")),
+        ("Styled block", Block::default().borders(Borders::ALL).style(Style::default().fg(Color::Red))),
+        ("Partial borders", Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+    ];
+    
+    for (name, block) in test_cases {
+        // Clear buffer for clean test
+        buffer.reset();
+        
+        // Render block
+        block.render(area, buffer);
+        
+        // Verify rendering didn't panic and produced content
+        let content = buffer.content();
+        assert!(!content.is_empty(), "Block '{}' produced no content", name);
+        
+        // Verify border cells are set (not default spaces)
+        if area.width > 0 && area.height > 0 {
+            let first_cell = &content[0];
+            // Border should have non-space content
+            assert_ne!(first_cell.symbol, " ", "Block '{}' didn't render border", name);
+        }
+    }
+}
+
+/// Test that Paragraph widget rendering works correctly
+#[test]
+fn test_paragraph_widget_migration_compatibility() {
+    let backend = TestBackend::new(30, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 30, 8);
+    
+    let test_texts = vec![
+        ("Simple text", Text::from("Simple paragraph text")),
+        ("Multi-line", Text::from("Line 1\nLine 2\nLine 3")),
+        ("Styled text", Text::from(Spans::from(vec![
+            Span::raw("Normal "),
+            Span::styled("Bold", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(" Red", Style::default().fg(Color::Red)),
+        ]))),
+    ];
+    
+    for (name, text) in test_texts {
+        buffer.reset();
+        
+        let paragraph = Paragraph::new(&text)
+            .block(Block::default().borders(Borders::ALL));
+        
+        paragraph.render(area, buffer);
+        
+        // Verify content was rendered
+        let content = buffer.content();
+        assert!(!content.is_empty(), "Paragraph '{}' produced no content", name);
+        
+        // Check that text content exists (non-border, non-space cells)
+        let has_text_content = content.iter().any(|cell| {
+            cell.symbol != " " && 
+            cell.symbol != "┌" && cell.symbol != "┐" && 
+            cell.symbol != "└" && cell.symbol != "┘" &&
+            cell.symbol != "─" && cell.symbol != "│"
+        });
+        assert!(has_text_content, "Paragraph '{}' has no text content", name);
+    }
+}
+
+/// Test Table widget rendering compatibility
+#[test]
+fn test_table_widget_migration_compatibility() {
+    let backend = TestBackend::new(40, 12);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 40, 12);
+    
+    // Create test table data
+    let header = Row::new(vec!["Col1", "Col2", "Col3"]);
+    let rows = vec![
+        Row::new(vec!["Row1-1", "Row1-2", "Row1-3"]),
+        Row::new(vec!["Row2-1", "Row2-2", "Row2-3"]),
+        Row::new(vec![
+            Cell::from("Styled"),
+            Cell::from("Cell").style(Style::default().fg(Color::Yellow)),
+            Cell::from("Content"),
+        ]),
+    ];
+    
+    buffer.reset();
+    
+    let table = Table::new(rows)
+        .header(header)
+        .block(Block::default().borders(Borders::ALL))
+        .widths(&[
+            Constraint::Length(10),
+            Constraint::Length(10), 
+            Constraint::Length(10),
+        ]);
+    
+    table.render(area, buffer);
+    
+    // Verify table was rendered
+    let content = buffer.content();
+    assert!(!content.is_empty(), "Table produced no content");
+    
+    // Check for table content (should have header and row data)
+    let text_content: Vec<&str> = content.iter()
+        .map(|cell| cell.symbol.as_str())
+        .filter(|s| !s.is_empty() && *s != " " && !is_border_char(s))
+        .collect();
+    
+    assert!(!text_content.is_empty(), "Table has no text content");
+}
+
+/// Test widget style propagation
+#[test] 
+fn test_widget_style_migration() {
+    let backend = TestBackend::new(15, 6);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 15, 6);
+    
+    let base_style = Style::default().fg(Color::Green).bg(Color::Blue);
+    let text_style = Style::default().fg(Color::Yellow);
+    
+    buffer.reset();
+    
+    let text = Text::from(Spans::from(vec![
+        Span::styled("Styled", text_style),
+        Span::raw(" text"),
+    ]));
+    
+    let paragraph = Paragraph::new(&text)
+        .block(Block::default()
+            .borders(Borders::ALL)
+            .style(base_style));
+    
+    paragraph.render(area, buffer);
+    
+    // Verify styles are applied
+    let content = buffer.content();
+    let styled_cells: Vec<_> = content.iter()
+        .filter(|cell| cell.fg == Color::Green || cell.fg == Color::Yellow)
+        .collect();
+    
+    assert!(!styled_cells.is_empty(), "No styled cells found");
+}
+
+/// Test widget edge cases and error handling
+#[test]
+fn test_widget_edge_cases() {
+    let backend = TestBackend::new(5, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    
+    // Test zero-size area
+    let zero_area = Rect::new(0, 0, 0, 0);
+    let block = Block::default().borders(Borders::ALL);
+    block.render(zero_area, buffer); // Should not panic
+    
+    // Test minimal area
+    let minimal_area = Rect::new(0, 0, 1, 1);
+    let block = Block::default().borders(Borders::ALL);
+    block.render(minimal_area, buffer); // Should not panic
+    
+    // Test paragraph with empty text
+    let empty_text = Text::from("");
+    let paragraph = Paragraph::new(&empty_text);
+    paragraph.render(Rect::new(0, 0, 5, 3), buffer); // Should not panic
+    
+    // Test table with no rows
+    let empty_table = Table::new(vec![])
+        .widths(&[Constraint::Length(5)]);
+    empty_table.render(Rect::new(0, 0, 5, 3), buffer); // Should not panic
+}
+
+/// Test widget layout and positioning
+#[test]
+fn test_widget_positioning() {
+    let backend = TestBackend::new(25, 15);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    
+    // Test rendering at different positions
+    let areas = vec![
+        Rect::new(0, 0, 10, 5),    // Top-left
+        Rect::new(10, 5, 15, 10),  // Bottom-right (overlapping)
+        Rect::new(5, 2, 8, 4),     // Middle
+    ];
+    
+    for (i, area) in areas.iter().enumerate() {
+        let title = format!("Block {}", i + 1);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(title.as_str());
+        
+        block.render(*area, buffer);
+    }
+    
+    // Verify multiple blocks were rendered
+    let content = buffer.content();
+    let border_cells = content.iter()
+        .filter(|cell| is_border_char(&cell.symbol))
+        .count();
+    
+    assert!(border_cells > 10, "Expected multiple blocks to be rendered");
+}
+
+/// Helper function to check if a string is a border character
+fn is_border_char(s: &str) -> bool {
+    matches!(s, "┌" | "┐" | "└" | "┘" | "─" | "│" | "├" | "┤" | "┬" | "┴" | "┼")
+}

--- a/helix-tui/tests/widgets_basic.rs
+++ b/helix-tui/tests/widgets_basic.rs
@@ -1,0 +1,158 @@
+use helix_tui::backend::{Backend, TestBackend};
+use helix_tui::Terminal;
+use helix_tui::buffer::Buffer;
+use helix_tui::widgets::{Block, Borders, Widget};
+use helix_view::graphics::{Color, Style, Rect};
+
+#[test]
+fn test_block_widget_rendering() {
+    let backend = TestBackend::new(10, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    // Test basic block rendering doesn't panic
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 10, 5);
+    
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title("Test");
+    
+    block.render(area, buffer);
+    
+    // Verify the block was rendered
+    let content = buffer.content();
+    assert!(!content.is_empty());
+    assert_eq!(content.len(), 50); // 10x5 = 50 cells
+}
+
+#[test]
+fn test_block_widget_borders() {
+    let backend = TestBackend::new(6, 4);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 6, 4);
+    
+    // Test different border combinations
+    let border_tests = vec![
+        Borders::empty(),
+        Borders::ALL,
+        Borders::LEFT,
+        Borders::RIGHT,
+        Borders::TOP,
+        Borders::BOTTOM,
+        Borders::LEFT | Borders::RIGHT,
+        Borders::TOP | Borders::BOTTOM,
+    ];
+    
+    for borders in border_tests {
+        let block = Block::default().borders(borders);
+        block.render(area, buffer);
+        // Just test it doesn't panic
+    }
+}
+
+#[test] 
+fn test_block_widget_styling() {
+    let backend = TestBackend::new(8, 3);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    let area = Rect::new(0, 0, 8, 3);
+    
+    // Test block with style
+    let style = Style::default().fg(Color::Red).bg(Color::Blue);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .style(style);
+    
+    block.render(area, buffer);
+    
+    // Check that some cells have the style applied
+    let content = buffer.content();
+    assert!(!content.is_empty());
+    
+    // The border cells should have the style
+    let first_cell = &content[0];
+    assert_eq!(first_cell.fg, Color::Red);
+    assert_eq!(first_cell.bg, Color::Blue);
+}
+
+#[test]
+fn test_widget_rendering_edge_cases() {
+    let backend = TestBackend::new(1, 1);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    let buffer = terminal.current_buffer_mut();
+    
+    // Test rendering in minimal area
+    let area = Rect::new(0, 0, 1, 1);
+    let block = Block::default().borders(Borders::ALL);
+    block.render(area, buffer);
+    
+    // Test zero area
+    let zero_area = Rect::new(0, 0, 0, 0);
+    let block = Block::default().borders(Borders::ALL);
+    block.render(zero_area, buffer); // Should not panic
+}
+
+#[test]
+fn test_buffer_with_lines_basic() {
+    // Test creating buffers from string lines
+    let lines = vec![
+        "Line 1",
+        "Line 2 is longer",
+        "Short",
+        "",
+        "Final line",
+    ];
+    
+    let buffer = Buffer::with_lines(lines.clone());
+    
+    assert_eq!(buffer.area().height, 5);
+    assert_eq!(buffer.area().width, 16); // Length of longest line
+    
+    // Verify content is accessible
+    let content = buffer.content();
+    assert_eq!(content.len(), 5 * 16);
+}
+
+#[test]
+fn test_buffer_string_setting() {
+    let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 10));
+    let style = Style::default().fg(Color::Yellow);
+    
+    // Test setting strings at various positions
+    buffer.set_string(0, 0, "Top left", style);
+    buffer.set_string(5, 5, "Middle", style);
+    buffer.set_string(0, 9, "Bottom", style);
+    
+    // Test unicode strings
+    buffer.set_string(0, 1, "Unicode: 日本語", style);
+    buffer.set_string(0, 2, "Emojis: 🚀🎉", style);
+    
+    // Verify strings were set (check non-empty cells)
+    if let Some(cell) = buffer.get(0, 0) {
+        assert_ne!(cell.symbol, " ");
+    }
+    if let Some(cell) = buffer.get(5, 5) {
+        assert_ne!(cell.symbol, " ");
+    }
+}
+
+#[test]
+fn test_terminal_buffer_swap() {
+    let backend = TestBackend::new(10, 5);
+    let mut terminal = Terminal::new(backend).unwrap();
+    
+    // Test multiple draws to ensure buffer swapping works
+    for i in 0..3 {
+        let result = terminal.draw(Some((i, i)), helix_view::graphics::CursorKind::Block);
+        assert!(result.is_ok(), "Draw {} failed", i);
+    }
+    
+    // Terminal should still be in a valid state
+    let size = terminal.backend().size().unwrap();
+    assert_eq!(size.width, 10);
+    assert_eq!(size.height, 5);
+}


### PR DESCRIPTION
We've got a ton of TUI code in here that adds maintenance I'd rather have upstream. 

Summary of changes:
- Adds a compatibility layer for ratatui <-> helix-tui conversions
- Adds a feature flag to allow building with the ratatui backend
- Very many tests and benchmarks
